### PR TITLE
Add container edits and related members

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ notify = "4.0.15"
 serde = "1.0.131"
 serde_derive = "1.0.131"
 libc = "0.2.112"
+nix = "0.28.0"
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/src/container_edits.rs
+++ b/src/container_edits.rs
@@ -1,0 +1,62 @@
+use anyhow::Result;
+use oci_spec::runtime as oci;
+
+use crate::{specs::config::ContainerEdits as CDIContainerEdits, utils::merge};
+
+// ContainerEdits represent updates to be applied to an OCI Spec.
+// These updates can be specific to a CDI device, or they can be
+// specific to a CDI Spec. In the former case these edits should
+// be applied to all OCI Specs where the corresponding CDI device
+// is injected. In the latter case, these edits should be applied
+// to all OCI Specs where at least one devices from the CDI Spec
+// is injected.
+#[derive(Clone, Default, Debug, Eq, PartialEq, Hash)]
+pub struct ContainerEdits {
+    pub container_edits: CDIContainerEdits,
+}
+
+impl ContainerEdits {
+    // Apply edits to the given OCI Spec. Updates the OCI Spec in place.
+    // Returns an error if the update fails.
+    pub fn new() -> Self {
+        Self {
+            container_edits: CDIContainerEdits {
+                ..Default::default()
+            },
+        }
+    }
+
+    pub fn apply(&mut self, _oci_spec: &mut oci::Spec) -> Result<()> {
+        // TODO: it depends on Generator related to oci spec, however, there's no existing
+        // Generator for us and the Generator depends on the MutGetters attribute on oci-spec-rs/runtime.
+        // It will be implemented once the PR https://github.com/containers/oci-spec-rs/pull/166 merged
+        Ok(())
+    }
+
+    pub fn append(&mut self, o: ContainerEdits) -> Self {
+        let intel_rdt = if o.container_edits.intel_rdt.is_some() {
+            o.container_edits.intel_rdt
+        } else {
+            None
+        };
+
+        let ce = CDIContainerEdits {
+            env: merge(&mut self.container_edits.env, &o.container_edits.env),
+            device_nodes: merge(
+                &mut self.container_edits.device_nodes,
+                &o.container_edits.device_nodes,
+            ),
+            hooks: merge(&mut self.container_edits.hooks, &o.container_edits.hooks),
+            mounts: merge(&mut self.container_edits.mounts, &o.container_edits.mounts),
+            intel_rdt,
+            additional_gids: merge(
+                &mut self.container_edits.additional_gids,
+                &o.container_edits.additional_gids,
+            ),
+        };
+
+        Self {
+            container_edits: ce,
+        }
+    }
+}

--- a/src/container_edits.rs
+++ b/src/container_edits.rs
@@ -1,7 +1,27 @@
-use anyhow::Result;
+use std::{collections::HashSet, str::FromStr};
+
+use anyhow::{anyhow, Context, Error, Result};
 use oci_spec::runtime as oci;
 
-use crate::{specs::config::ContainerEdits as CDIContainerEdits, utils::merge};
+use crate::{
+    specs::config::{
+        ContainerEdits as CDIContainerEdits, DeviceNode as CDIDeviceNode, Hook as CDIHook,
+        IntelRdt as CDIIntelRdt, Mount as CDIMount,
+    },
+    utils::merge,
+};
+
+pub trait Validate {
+    fn validate(&self) -> Result<()>;
+}
+
+fn validate_envs(envs: &[String]) -> Result<()> {
+    if envs.iter().any(|v| !v.contains('=')) {
+        return Err(anyhow!("invalid environment variable: {:?}", envs));
+    }
+
+    Ok(())
+}
 
 // ContainerEdits represent updates to be applied to an OCI Spec.
 // These updates can be specific to a CDI device, or they can be
@@ -58,5 +78,170 @@ impl ContainerEdits {
         Self {
             container_edits: ce,
         }
+    }
+}
+
+impl Validate for ContainerEdits {
+    fn validate(&self) -> Result<()> {
+        if let Some(envs) = &self.container_edits.env {
+            validate_envs(envs)
+                .context(format!("invalid container edits with envs: {:?}", envs))?;
+        }
+        if let Some(devices) = &self.container_edits.device_nodes {
+            for d in devices {
+                let dn = DeviceNode { node: d.clone() };
+                dn.validate()
+                    .context(format!("invalid container edits with device: {:?}", &d))?;
+            }
+        }
+        if let Some(hooks) = &self.container_edits.hooks {
+            for h in hooks {
+                let hook = Hook { hook: h.clone() };
+                hook.validate()
+                    .context(format!("invalid container edits with hook: {:?}", &h))?;
+            }
+        }
+        if let Some(mounts) = &self.container_edits.mounts {
+            for m in mounts {
+                let mnt = Mount { mount: m.clone() };
+                mnt.validate()
+                    .context(format!("invalid container edits with mount: {:?}", &m))?;
+            }
+        }
+        if let Some(irdt) = &self.container_edits.intel_rdt {
+            let i_rdt = IntelRdt {
+                intel_rdt: irdt.clone(),
+            };
+            i_rdt
+                .validate()
+                .context(format!("invalid container edits with mount: {:?}", irdt))?;
+        }
+
+        Ok(())
+    }
+}
+
+// DeviceNode is a CDI Spec DeviceNode wrapper, used for validating DeviceNodes.
+pub struct DeviceNode {
+    pub node: CDIDeviceNode,
+}
+
+impl Validate for DeviceNode {
+    fn validate(&self) -> Result<()> {
+        let typs = vec!["b", "c", "u", "p", ""];
+        let valid_typs: HashSet<&str> = typs.into_iter().collect();
+
+        if self.node.path.is_empty() {
+            return Err(anyhow!("invalid (empty) device path"));
+        }
+
+        if let Some(typ) = &self.node.r#type {
+            if valid_typs.contains(&typ.as_str()) {
+                return Err(anyhow!(
+                    "device {:?}: invalid type {:?}",
+                    self.node.path,
+                    typ
+                ));
+            }
+        }
+
+        if let Some(perms) = &self.node.permissions {
+            if !perms.chars().all(|c| matches!(c, 'r' | 'w' | 'm')) {
+                return Err(anyhow!(
+                    "device {}: invalid permissions {}",
+                    self.node.path,
+                    perms
+                ));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+enum HookName {
+    Prestart,
+    CreateRuntime,
+    CreateContainer,
+    StartContainer,
+    Poststart,
+    Poststop,
+}
+
+impl FromStr for HookName {
+    type Err = Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "prestart" => Ok(Self::Prestart),
+            "createRuntime" => Ok(Self::CreateRuntime),
+            "createContainer" => Ok(Self::CreateContainer),
+            "startContainer" => Ok(Self::StartContainer),
+            "poststart" => Ok(Self::Poststart),
+            "poststop" => Ok(Self::Poststop),
+            _ => Err(anyhow!("no such hook")),
+        }
+    }
+}
+
+struct Hook {
+    hook: CDIHook,
+}
+
+impl Validate for Hook {
+    fn validate(&self) -> Result<()> {
+        HookName::from_str(&self.hook.hook_name)
+            .context(anyhow!("invalid hook name: {:?}", self.hook.hook_name))?;
+
+        if self.hook.path.is_empty() {
+            return Err(anyhow!(
+                "invalid hook {:?} with empty path",
+                self.hook.hook_name
+            ));
+        }
+        if let Some(envs) = &self.hook.env {
+            validate_envs(envs)
+                .context(anyhow!("hook {:?} with invalid env", &self.hook.hook_name))?;
+        }
+
+        Ok(())
+    }
+}
+
+struct Mount {
+    mount: CDIMount,
+}
+
+impl Validate for Mount {
+    fn validate(&self) -> Result<()> {
+        if self.mount.host_path.is_empty() {
+            return Err(anyhow!("invalid mount, empty host path"));
+        }
+
+        if self.mount.container_path.is_empty() {
+            return Err(anyhow!("invalid mount, empty container path"));
+        }
+
+        Ok(())
+    }
+}
+
+struct IntelRdt {
+    intel_rdt: CDIIntelRdt,
+}
+
+impl Validate for IntelRdt {
+    fn validate(&self) -> Result<()> {
+        if let Some(ref clos_id) = self.intel_rdt.clos_id {
+            if clos_id.len() >= 4096
+                || clos_id == "."
+                || clos_id == ".."
+                || clos_id.contains(|c| c == '/' || c == '\n')
+            {
+                return Err(anyhow!("invalid clos id".to_string()));
+            }
+        }
+
+        Ok(())
     }
 }

--- a/src/container_edits_unix.rs
+++ b/src/container_edits_unix.rs
@@ -1,0 +1,197 @@
+use std::{
+    io::{Error, ErrorKind},
+    os::unix::fs::{FileTypeExt, MetadataExt},
+    path::Path,
+};
+
+use anyhow::Result;
+
+pub enum DeviceType {
+    Block,
+    Char,
+    Fifo,
+}
+
+impl ToString for DeviceType {
+    fn to_string(&self) -> String {
+        match self {
+            DeviceType::Block => "b".to_string(),
+            DeviceType::Char => "c".to_string(),
+            DeviceType::Fifo => "p".to_string(),
+        }
+    }
+}
+
+// deviceInfoFromPath takes the path to a device and returns its type, major and minor device numbers.
+// It was adapted from https://github.com/opencontainers/runc/blob/v1.1.9/libcontainer/devices/device_unix.go#L30-L69
+pub fn device_info_from_path<P: AsRef<Path>>(path: P) -> Result<(String, i64, i64)> {
+    // In major, 0x00_00_00_00_ff_ff_ff_ff is a hexadecimal constant value used for bitmasking the result of dev >> 8,
+    // which is used to extract the major device number from the dev value by leveraging bitwise operations.
+    let major = |dev: u64| -> i64 { (dev >> 8) as i64 & 0x00_00_00_00_ff_ff_ff_ff };
+    // the closure fn minor uses bitmasking with the constant 0x00_00_00_00_00_00_ff_ff to extract the low 16 bits of dev,
+    // which correspond to the minor device number in Unix systems.
+    let minor = |dev: u64| -> i64 { dev as i64 & 0x00_00_00_00_00_00_ff_ff };
+
+    let metadata = std::fs::metadata(path)?;
+    let file_type = metadata.file_type();
+
+    let (dev_type, major, minor) = if file_type.is_block_device() {
+        (
+            DeviceType::Block.to_string(),
+            major(metadata.rdev()),
+            minor(metadata.rdev()),
+        )
+    } else if file_type.is_char_device() {
+        (
+            DeviceType::Char.to_string(),
+            major(metadata.rdev()),
+            minor(metadata.rdev()),
+        )
+    } else if file_type.is_fifo() {
+        (DeviceType::Fifo.to_string(), 0, 0)
+    } else {
+        return Err(Error::new(ErrorKind::InvalidInput, "It's not a device node").into());
+    };
+
+    Ok((dev_type, major, minor))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::ffi::CString;
+
+    use anyhow::Result;
+    use nix::libc::{self, dev_t, mknodat, mode_t, S_IFBLK, S_IFCHR, S_IFIFO};
+    use tempfile::TempDir;
+
+    use crate::{container_edits::DeviceNode, specs::config::DeviceNode as CDIDeviceNode};
+
+    fn is_root() -> bool {
+        unsafe { libc::geteuid() == 0 }
+    }
+
+    fn create_device(path: &str, mode: mode_t, dev: u64, dev_type: &str) -> Result<()> {
+        let path_c = CString::new(path)?;
+
+        // Set the appropriate mode for block or char or fifo device
+        let mode = match dev_type {
+            "b" => mode | S_IFBLK,
+            "c" => mode | S_IFCHR,
+            "p" => mode | S_IFIFO,
+            _ => 0,
+        };
+
+        // Create the device
+        let res = unsafe { mknodat(libc::AT_FDCWD, path_c.as_ptr(), mode, dev as dev_t) };
+        if res < 0 {
+            println!("create device with path: {:?} failed", path);
+            return Err(nix::Error::last().into());
+        }
+
+        println!("create device with path: {:?} successfully", path);
+        Ok(())
+    }
+
+    #[test]
+    fn test_fill_missing_info_block_device() {
+        if !is_root() {
+            println!("INFO: skipping, needs root");
+            return;
+        }
+
+        let temp_dir = TempDir::new().unwrap();
+        let block_device_path = temp_dir.path().join("block_device").display().to_string();
+
+        // Create a block device
+        let res = create_device(&block_device_path, 0o666, 0x0101, "b");
+        assert!(res.is_ok(), "Failed to create block device: {:?}", res);
+
+        let mut dev_node = DeviceNode {
+            node: CDIDeviceNode {
+                path: block_device_path,
+                ..Default::default()
+            },
+        };
+
+        assert!(dev_node.fill_missing_info().is_ok());
+
+        assert_eq!(dev_node.node.r#type, Some(DeviceType::Block.to_string()));
+        assert_eq!(dev_node.node.major, Some(1));
+        assert_eq!(dev_node.node.minor, Some(1));
+    }
+
+    #[test]
+    fn test_fill_missing_info_char_device() {
+        if !is_root() {
+            println!("INFO: skipping, needs root");
+            return;
+        }
+
+        let temp_dir = TempDir::new().unwrap();
+        let char_device_path = temp_dir.path().join("char_device").display().to_string();
+
+        // Create a character device
+        let res = create_device(&char_device_path, 0o666, 0x0202, "c");
+        assert!(res.is_ok(), "Failed to create char device: {:?}", res);
+
+        let mut dev_node = DeviceNode {
+            node: CDIDeviceNode {
+                path: char_device_path,
+                ..Default::default()
+            },
+        };
+
+        assert!(dev_node.fill_missing_info().is_ok());
+
+        assert_eq!(dev_node.node.r#type, Some(DeviceType::Char.to_string()));
+        assert_eq!(dev_node.node.major, Some(1));
+        assert_eq!(dev_node.node.minor, Some(2));
+    }
+
+    #[test]
+    fn test_fill_missing_info_fifo() {
+        if !is_root() {
+            println!("INFO: skipping which needs root");
+            return;
+        }
+
+        let temp_dir = TempDir::new().unwrap();
+        let fifo_device_path = temp_dir.path().join("fifo_device").display().to_string();
+
+        // Create a character device
+        let res = create_device(&fifo_device_path, 0o666, 0x0, "p");
+        assert!(res.is_ok(), "Failed to create fifo device: {:?}", res);
+
+        let mut dev_node = DeviceNode {
+            node: CDIDeviceNode {
+                path: fifo_device_path,
+                ..Default::default()
+            },
+        };
+
+        dev_node.fill_missing_info().unwrap();
+
+        assert_eq!(dev_node.node.r#type, Some(DeviceType::Fifo.to_string()));
+        assert_eq!(dev_node.node.major, None);
+        assert_eq!(dev_node.node.minor, None);
+    }
+
+    #[test]
+    fn test_fill_missing_info_regular_file() {
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("regular_file");
+        std::fs::File::create(&file_path).unwrap();
+
+        let mut dev_node = DeviceNode {
+            node: CDIDeviceNode {
+                path: file_path.to_string_lossy().to_string(),
+                ..Default::default()
+            },
+        };
+
+        let result = dev_node.fill_missing_info();
+        assert!(result.is_err());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ use cache::CacheOption;
 
 pub mod annotations;
 pub mod cache;
+pub mod container_edits;
 pub mod device;
 pub mod parser;
 pub mod registry;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ use cache::CacheOption;
 pub mod annotations;
 pub mod cache;
 pub mod container_edits;
+pub mod container_edits_unix;
 pub mod device;
 pub mod parser;
 pub mod registry;


### PR DESCRIPTION
1. Add ContainerEdits and implement its related methods;
2. Add other related members of ContainerEdits, such as DeviceNode, Mount, Hook and so on.
3. Implement fill_missing_info for DeviceNode 