### PR TITLE
add or refactir cdi bin or validate bin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/bin/validate.rs" # Path to the source file
 [dependencies]
 oci-spec = "0.6.4"
 anyhow = "1.0"
-clap = "3.1"
+clap = "4.5.3"
 serde_json = "1.0"
 jsonschema = "0.17.1"
 once_cell = "1.8.0"

--- a/src/bin/cdi.rs
+++ b/src/bin/cdi.rs
@@ -1,7 +1,25 @@
 extern crate cdi;
-//use clap::{Arg, Subcommand};
+mod cdi_ops;
 
-fn main() {
+use anyhow::Result;
+use clap::Parser;
 
-    // Here, you can use your library's functions or structs.
+use cdi_ops::{
+    args::{CdiCli, Commands},
+    handler::{handle_cdi_devices, handle_cdi_inject},
+};
+
+fn main() -> Result<()> {
+    let cli = CdiCli::parse();
+
+    match &cli.command {
+        Commands::Devices(args) => {
+            handle_cdi_devices(args)?;
+        }
+        Commands::Inject(args) => {
+            handle_cdi_inject(args)?;
+        } // TODO: to support more command here
+    }
+
+    Ok(())
 }

--- a/src/bin/cdi_ops/args.rs
+++ b/src/bin/cdi_ops/args.rs
@@ -1,0 +1,77 @@
+use clap::{Args, Parser, Subcommand};
+
+#[derive(Parser)]
+#[command(
+    version,
+    about,
+    long_about = "The 'cdi' utility allows you to inspect and interact with the
+CDI Registry. Various commands are available for listing CDI
+Spec files, vendors, classes, devices, validating the content
+of the registry, injecting devices into OCI Specs, and for
+monitoring changes in the Registry.
+
+See cdi --help for a list of available commands. You can get
+additional help about <command> by using 'cdi <command> -h'.
+"
+)]
+#[command(propagate_version = true)]
+pub struct CdiCli {
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(Subcommand)]
+pub enum Commands {
+    /// List devices in the CDI registry
+    #[clap(
+        about = "List devices in the CDI registry.",
+        long_about = "The 'devices' command lists devices found in the CDI registry."
+    )]
+    Devices(DevicesArgs),
+
+    /// Inject CDI devices into an OCI Spec.
+    #[clap(
+        about = "Inject CDI devices into an OCI Spec.",
+        long_about = "The 'inject' command reads an OCI Spec from a file (use \"-\" for stdin),
+injects a requested set of CDI devices into it and dumps the resulting
+updated OCI Spec."
+    )]
+    Inject(InjectArgs),
+}
+
+#[derive(Debug, Args)]
+#[command(
+    version,
+    about,
+    long_about = "The 'devices' command lists devices found in the CDI registry."
+)]
+pub struct DevicesArgs {
+    #[arg(
+        short = 'o',
+        long = "output",
+        default_value = " ",
+        help = "output format for OCI Spec (json|yaml)"
+    )]
+    pub format: String,
+    #[arg(short = 'v', long = "verbose", help = "list CDI Spec details")]
+    pub verbose: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct InjectArgs {
+    /// OCI Spec File
+    #[arg(required = true, value_parser)]
+    pub oci_spec: String,
+
+    /// CDI Device List
+    #[arg(required = true, value_parser)]
+    pub cdi_devices: Vec<String>,
+
+    #[arg(
+        short = 'o',
+        long = "output",
+        default_value = " ",
+        help = "output format for OCI Spec (json|yaml)"
+    )]
+    pub format: String,
+}

--- a/src/bin/cdi_ops/handler.rs
+++ b/src/bin/cdi_ops/handler.rs
@@ -1,0 +1,20 @@
+use anyhow::Result;
+
+use super::args::{DevicesArgs, InjectArgs};
+
+pub fn handle_cdi_inject(args: &InjectArgs) -> Result<()> {
+    println!("{:?}", args.oci_spec);
+    println!("{:?}", args.cdi_devices);
+
+    // TODO: add complete work later.
+    // let oci_spec = &mut read_oci_spec(&args.oci_spec)?;
+    // cdi_inject_devices(oci_spec, args.cdi_devices.clone()).context("cdi inject devices failed")?;
+
+    Ok(())
+}
+
+pub fn handle_cdi_devices(args: &DevicesArgs) -> Result<()> {
+    println!("{:#?}", args);
+
+    Ok(())
+}

--- a/src/bin/cdi_ops/mod.rs
+++ b/src/bin/cdi_ops/mod.rs
@@ -1,0 +1,2 @@
+pub mod args;
+pub mod handler;

--- a/src/bin/validate.rs
+++ b/src/bin/validate.rs
@@ -1,59 +1,13 @@
-use anyhow::Result;
-use clap::{App, Arg};
-use std::io::{self, Read};
+use anyhow::{Context, Result};
+use clap::Parser;
 
-extern crate cdi;
+mod validate_ops;
 
-// use cdi::schema;
+use validate_ops::{args::ValidateArgs, handler::handle_validate};
 
 fn main() -> Result<()> {
-    let matches = App::new("validate")
-        .version("1.0")
-        .about(
-            "Validates JSON documents against a schema
-
-  1.specify document file as an argument
-    validate --schema <schema.json> <document.json>
-      
-  2.pass document content through a pipe
-    cat <document.json> | validate --schema <schema.json>
-
-  3.input document content manually, ended with ctrl+d(or your self-defined EOF keys)
-    validate --schema <schema.json>
-    [INPUT DOCUMENT CONTENT HERE]	    
-	    ",
-        )
-        .arg(
-            Arg::with_name("schema")
-                .long("schema")
-                .value_name("FILE")
-                .default_value("builtin")
-                .help("JSON Schema to validate against"),
-        )
-        .arg(
-            Arg::new("document")
-                .help("The document to validate")
-                .index(1)
-                .default_value("-")
-                .required(false),
-        )
-        .get_matches();
-
-    let schema_file = matches.value_of("schema").unwrap_or("builtin");
-    println!("Validating against JSON schema {}...", schema_file);
-
-    let document = matches.value_of("document").unwrap();
-
-    let _doc_data = if document == "-" {
-        println!("Reading from <stdin>...");
-        let mut buffer = Vec::new();
-        io::stdin().read_to_end(&mut buffer)?;
-        buffer
-    } else {
-        std::fs::read(document)?
-    };
-
-    //schema::validate(schema_file, &doc_data)
+    let args = ValidateArgs::parse();
+    handle_validate(args).context("handle validate failed")?;
 
     Ok(())
 }

--- a/src/bin/validate_ops/args.rs
+++ b/src/bin/validate_ops/args.rs
@@ -1,0 +1,29 @@
+use clap::Parser;
+
+#[derive(Clone, Debug, Parser)]
+#[command(
+    name = "validate",
+    version = "0.1.0",
+    about = "validate cli",
+    long_about = "Validate is used to check document with specified schema.
+You can use validate in following ways:
+
+1.specify document file as an argument
+  validate --schema <schema.json> <document.json>
+    
+2.pass document content through a pipe
+  cat <document.json> | validate --schema <schema.json>
+
+3.input document content manually, ended with ctrl+d(or your self-defined EOF keys)
+  validate --schema <schema.json>
+  [INPUT DOCUMENT CONTENT HERE]	    
+"
+)]
+pub struct ValidateArgs {
+    /// JSON Schema to validate against (default "builtin")
+    #[arg(long = "schema", default_value = "builtin")]
+    pub schema: String,
+    /// Document to be validated (default "-") and it's regarded as index argument
+    #[arg(value_name = "document", default_value = "-", index = 1)]
+    pub document: String,
+}

--- a/src/bin/validate_ops/handler.rs
+++ b/src/bin/validate_ops/handler.rs
@@ -1,0 +1,22 @@
+use std::io::{self, Read};
+
+use anyhow::Result;
+
+use crate::ValidateArgs;
+
+/// handle_validate is used to handle the input arguments
+pub fn handle_validate(args: ValidateArgs) -> Result<()> {
+    println!("args: {:?}", args);
+    let _doc_data = if args.document == "-" {
+        println!("Reading from <stdin>...");
+        let mut buffer = Vec::new();
+        io::stdin().read_to_end(&mut buffer)?;
+        buffer
+    } else {
+        std::fs::read(&args.document)?
+    };
+
+    // TODO:
+    // schema::validate(args.schema, &doc_data)
+    Ok(())
+}

--- a/src/bin/validate_ops/mod.rs
+++ b/src/bin/validate_ops/mod.rs
@@ -1,0 +1,2 @@
+pub mod args;
+pub mod handler;


### PR DESCRIPTION
cdi: add initalized cdi binary implementation

It's the first part of cdi bin implementation focusing
on the framework building with clap.

validate: refactor the initalized validate implementation

Do refactor the inital implementation of validate and align
its implementation with the approach used in the cdi bin.

Signed-off-by: Alex Lyn <alex.lyn@antgroup.com>