### PR TITLE
Add Cargo.toml definitions for publishing the crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,13 @@
 name = "cdi"
 version = "0.1.0"
 edition = "2021"
+license-file = "LICENSE"
+description = "CDI (Container Device Interface), is a specification, for container-runtimes, to support third-party devices."
+repository = "https://github.com/zvonkok/container-device-interface-rs"
+homepage = "https://github.com/cncf-tags/container-device-interface"
+readme = "README.md"
+categories = ["command-line-utilities"]
+keywords = ["container"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]


### PR DESCRIPTION
```
❯ cargo publish --dry-run
    Updating crates.io index
error: all dependencies must have a version specified when publishing.
dependency `oci-spec` does not specify a version
Note: The published dependency will use the version from crates.io,
the `git` specification will be removed from the dependency declaration.
```

We need to wait for the oci-spec release. 