### PR TITLE
Handle empty devices in OCI spec

### DIFF
--- a/src/generate/config.rs
+++ b/src/generate/config.rs
@@ -53,6 +53,18 @@ impl Generator {
         }
     }
 
+    pub fn init_config_linux_resources_devices(&mut self) {
+        self.init_config_linux_resources();
+
+        if let Some(linux) = self.config.as_mut().unwrap().linux_mut() {
+            if let Some(resource) = linux.resources_mut() {
+                if resource.devices().is_none() {
+                    resource.set_devices(Some(Vec::new()));
+                }
+            }
+        }
+    }
+
     pub fn init_config_hooks(&mut self) {
         self.init_config();
 

--- a/src/generate/generator.rs
+++ b/src/generate/generator.rs
@@ -47,7 +47,7 @@ impl Generator {
         minor: Option<i64>,
         access: Option<String>,
     ) {
-        self.init_config_linux_resources();
+        self.init_config_linux_resources_devices();
         if let Some(linux) = self.config.as_mut().unwrap().linux_mut() {
             if let Some(resource) = linux.resources_mut() {
                 if let Some(devices) = resource.devices_mut() {


### PR DESCRIPTION
Handle empty devices in OCI spec, if OCI spec has an empty linux.resource.devices entry aka None the CDI injection will fail since we are checking for Some(devices). 

If devices is None create an vector with the new device and set it in the resources section. 

With 
```---
cdiVersion: 0.5.0
containerEdits:
  deviceNodes:
  - path: /dev/nvidia0
  - path: /dev/nvidiactl
```

we get 
```
    "linux": {
      "resources": {
        "devices": [
          {
            "allow": true,
            "type": "c",
            "major": 195,
            "minor": 0,
            "access": "rwm"
          },
          {
            "allow": true,
            "type": "c",
            "major": 195,
            "minor": 0,
            "access": "rwm"
          },
          {
            "allow": true,
            "type": "c",
            "major": 242,
            "minor": 0,
            "access": "rwm"
          }
        ]
      },
```
Without the patch we got 

```
   "linux": {
      "resources": {},
```


