### PR TITLE
Dependabot/cargo/jsonschema 0.21.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,13 +22,12 @@ name = "validate" # Name of the binary executable
 path = "src/bin/validate.rs" # Path to the source file
 
 
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 oci-spec = { version = "0.6.6", features = ["runtime"] }
 anyhow = "1.0"
-clap = "4.5.4"
+clap = { version = "4.5.4", features = ["derive"] }
 serde_json = "1.0"
 jsonschema = "0.28.3"
 once_cell = "1.8.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ oci-spec = { version = "0.6.6", features = ["runtime"] }
 anyhow = "1.0"
 clap = "4.5.4"
 serde_json = "1.0"
-jsonschema = "0.18.0"
+jsonschema = "0.28.3"
 once_cell = "1.8.0"
 notify = "6.1.1"
 serde = "1.0.131"

--- a/src/bin/cdi_ops/utils.rs
+++ b/src/bin/cdi_ops/utils.rs
@@ -32,7 +32,6 @@ pub fn read_oci_spec(path: &str) -> Result<oci::Spec> {
 }
 
 #[cfg(test)]
-
 mod tests {
     use crate::cdi_ops::utils::find_target_devices;
 

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -1,7 +1,7 @@
 use anyhow::Ok;
 // use core::panic;
 // use jsonschema::Draft;
-// use jsonschema::JSONSchema;
+// use jsonschema::Validator;
 // use serde_json::json;
 // use serde_json::Value;
 
@@ -10,7 +10,7 @@ use anyhow::Result;
 const _SCHEMA_JSON: &str = include_str!("schema.json");
 const _DEFS_JSON: &str = include_str!("defs.json");
 
-pub fn validate(_schema: &jsonschema::JSONSchema, _doc_data: &[u8]) -> Result<()> {
+pub fn validate(_schema: &jsonschema::Validator, _doc_data: &[u8]) -> Result<()> {
     let mut schema_json: serde_json::Value = serde_json::from_str(include_str!("schema.json"))?;
     let defs_json: serde_json::Value = serde_json::from_str(include_str!("defs.json"))?;
 
@@ -19,7 +19,7 @@ pub fn validate(_schema: &jsonschema::JSONSchema, _doc_data: &[u8]) -> Result<()
         obj.insert("definitions".to_string(), defs_json);
     }
     /*
-        let compiled_schema = JSONSchema::options()
+        let compiled_schema = Validator::options()
             .with_draft(Draft::Draft7) // Adjust the draft version as needed
             .compile(&schema_json)?;
 
@@ -34,7 +34,7 @@ pub fn validate(_schema: &jsonschema::JSONSchema, _doc_data: &[u8]) -> Result<()
 
 /*
 fn validate_data(schema: &Value, data: &Value) -> Result<(), Vec<jsonschema::ValidationError>> {
-    let compiled_schema = JSONSchema::options()
+    let compiled_schema = Validator::options()
         .with_draft(Draft::Draft7) // Adjust the draft version as needed
         .compile(schema)?;
 
@@ -43,7 +43,7 @@ fn validate_data(schema: &Value, data: &Value) -> Result<(), Vec<jsonschema::Val
 
 
 
-pub fn load(schema_file: &str) -> Result<jsonschema::JSONSchema> {
+pub fn load(schema_file: &str) -> Result<jsonschema::Validator> {
 
     let schema_context = SchemaContext::builtin()?;
     Ok(schema_context.compiled_schema)
@@ -53,7 +53,7 @@ pub fn load(schema_file: &str) -> Result<jsonschema::JSONSchema> {
 
         print!("schema:\n{}", builtin_schema);
 
-        match jsonschema::JSONSchema::compile(&serde_json::from_str(&builtin_schema)?) {
+        match jsonschema::Validator::compile(&serde_json::from_str(&builtin_schema)?) {
             Ok(schema) => return Ok(schema),
             Err(e) => return Err(anyhow!("failed to compile builtin schema {}", e)),
         }
@@ -63,7 +63,7 @@ pub fn load(schema_file: &str) -> Result<jsonschema::JSONSchema> {
 }
 
 
- pub fn validate(schema: &jsonschema::JSONSchema, doc_data: &[u8]) -> Result<()> {
+ pub fn validate(schema: &jsonschema::Validator, doc_data: &[u8]) -> Result<()> {
     let doc = serde_json::from_slice(doc_data)?;
     match schema.validate(&doc) {
         Ok(_) => (),

--- a/src/version.rs
+++ b/src/version.rs
@@ -98,7 +98,7 @@ fn requires_v070(spec: &CDISpec) -> bool {
         if edits
             .additional_gids
             .as_ref()
-            .map_or(false, |v| !v.is_empty())
+            .is_some_and(|v| !v.is_empty())
         {
             return true;
         }
@@ -113,7 +113,7 @@ fn requires_v070(spec: &CDISpec) -> bool {
         if edits
             .additional_gids
             .as_ref()
-            .map_or(false, |v| !v.is_empty())
+            .is_some_and(|v| !v.is_empty())
         {
             return true;
         }
@@ -157,7 +157,7 @@ fn requires_v050(spec: &CDISpec) -> bool {
         .any(|node| {
             node.host_path
                 .as_deref()
-                .map_or(false, |path| !path.is_empty())
+                .is_some_and(|path| !path.is_empty())
         })
 }
 
@@ -167,5 +167,5 @@ fn requires_v040(spec: &CDISpec) -> bool {
         .map(|d| &d.container_edits)
         .chain(spec.container_edits.as_ref())
         .flat_map(|edits| edits.mounts.iter().flat_map(|mounts| mounts.iter()))
-        .any(|mount| mount.r#type.as_ref().map_or(false, |typ| !typ.is_empty()))
+        .any(|mount| mount.r#type.as_ref().is_some_and(|typ| !typ.is_empty()))
 }


### PR DESCRIPTION
With jsonschema v0.21.0 we get the error:
```
error[E0412]: cannot find type `JSONSchema` in crate `jsonschema`
```
this is because the struct was renamed to Validator in
[v0.20.0](https://github.com/Stranger6667/jsonschema/releases/tag/rust-v0.20.0)
so update this reference along with the jsonschema version bump