### PR TITLE
Add new release, fix LICENSE field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "container-device-interface"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "Apache-2.0"
 description = "CDI (Container Device Interface), is a specification, for container-runtimes, to support third-party devices."


### PR DESCRIPTION
When you point at a license file in Cargo.toml, the resultant published crate on crates.io will specify "non-standard" for the license entry. The guidance from the Rust team is when using standard licenses to specify the specific license in the license entry of Cargo.toml.

See the detailed discussion in https://github.com/rust-lang/cargo/issues/8537 for more info