### PR TITLE
fix: major and minor number for devices in container edits.

### DIFF
--- a/src/container_edits_unix.rs
+++ b/src/container_edits_unix.rs
@@ -147,7 +147,10 @@ mod tests {
 
     #[test]
     fn test_fill_missing_info_block_device_large_major_minor() {
-        assert!(is_root(), "needs root");
+        if !is_root() {
+            println!("INFO: skipping, needs root");
+            return;
+        }
 
         let temp_dir = TempDir::new().unwrap();
         let block_device_path = temp_dir

--- a/src/container_edits_unix.rs
+++ b/src/container_edits_unix.rs
@@ -141,8 +141,37 @@ mod tests {
         assert!(dev_node.fill_missing_info().is_ok());
 
         assert_eq!(dev_node.node.r#type, Some(DeviceType::Char.to_string()));
-        assert_eq!(dev_node.node.major, Some(1));
+        assert_eq!(dev_node.node.major, Some(2));
         assert_eq!(dev_node.node.minor, Some(2));
+    }
+
+    #[test]
+    fn test_fill_missing_info_block_device_large_major_minor() {
+        assert!(is_root(), "needs root");
+
+        let temp_dir = TempDir::new().unwrap();
+        let block_device_path = temp_dir
+            .path()
+            .join("block_device_large")
+            .display()
+            .to_string();
+
+        let dev = libc::makedev(259, 513) as u64;
+        let res = create_device(&block_device_path, 0o666, dev, "b");
+        assert!(res.is_ok(), "Failed to create block device: {:?}", res);
+
+        let mut dev_node = DeviceNode {
+            node: CDIDeviceNode {
+                path: block_device_path,
+                ..Default::default()
+            },
+        };
+
+        assert!(dev_node.fill_missing_info().is_ok());
+
+        assert_eq!(dev_node.node.r#type, Some(DeviceType::Block.to_string()));
+        assert_eq!(dev_node.node.major, Some(259));
+        assert_eq!(dev_node.node.minor, Some(513));
     }
 
     #[test]

--- a/src/container_edits_unix.rs
+++ b/src/container_edits_unix.rs
@@ -27,23 +27,20 @@ impl fmt::Display for DeviceType {
 // deviceInfoFromPath takes the path to a device and returns its type, major and minor device numbers.
 // It was adapted from https://github.com/opencontainers/runc/blob/v1.1.9/libcontainer/devices/device_unix.go#L30-L69
 pub fn device_info_from_path<P: AsRef<Path>>(path: P) -> Result<(String, i64, i64)> {
-    let major = |dev: u64| -> i64 { (dev >> 8) as i64 & 0xff };
-    let minor = |dev: u64| -> i64 { dev as i64 & 0xff };
-
     let metadata = std::fs::metadata(path)?;
     let file_type = metadata.file_type();
 
     let (dev_type, major, minor) = if file_type.is_block_device() {
         (
             DeviceType::Block.to_string(),
-            major(metadata.rdev()),
-            minor(metadata.rdev()),
+            libc::major(metadata.rdev()),
+            libc::minor(metadata.rdev()),
         )
     } else if file_type.is_char_device() {
         (
             DeviceType::Char.to_string(),
-            major(metadata.rdev()),
-            minor(metadata.rdev()),
+            libc::major(metadata.rdev()),
+            libc::minor(metadata.rdev()),
         )
     } else if file_type.is_fifo() {
         (DeviceType::Fifo.to_string(), 0, 0)
@@ -51,7 +48,7 @@ pub fn device_info_from_path<P: AsRef<Path>>(path: P) -> Result<(String, i64, i6
         return Err(Error::new(ErrorKind::InvalidInput, "It's not a device node").into());
     };
 
-    Ok((dev_type, major, minor))
+    Ok((dev_type, major.into(), minor.into()))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Purpose
I hit a bug where the major number of some devices would get truncated, for example:

Devices on host:
```sh
root@ubuntu:/# ls -lah /dev/nvhost-gpu /dev//nvhost-ctrl-gpu
crw-rw-rw- 1 root root 490, 2 Jan 19 09:58 /dev//nvhost-ctrl-gpu
crw-rw-rw- 1 root root 490, 1 Jan 19 09:58 /dev/nvhost-gpu
```
Would have truncated `major` number in the container:

```sh
root@00000000:/# ls -lah /dev/nvhost-gpu /dev/nvhost-ctrl-gpu
crw-rw-rw- 1 root root 234, 2 Jan 19 09:59 /dev/nvhost-ctrl-gpu
crw-rw-rw- 1 root root 234, 1 Jan 19 09:59 /dev/nvhost-gpu
````


The container was based on an oci config with applied container edits using this snippet:
```rs
let devices = vec![String::from("nvidia.com/gpu=all")];
container_device_interface::default_cache::inject_devices(&mut spec, devices)?;
```

## Specification
Use libc's implementations of `major` and `minor` instead of relying on a manual implementation.


##  Dependencies & Potential Impact
Depends on libc, the libc impl will bring better compatibility since there are a bunch of implementations for `major` and `minor`:

```sh
libc-0.2.180$ grep -r "pub const fn major" ./
./src/fuchsia/mod.rs:    pub const fn major(dev: crate::dev_t) -> c_uint {
./src/unix/bsd/netbsdlike/netbsd/mod.rs:    pub const fn major(dev: crate::dev_t) -> c_int {
./src/unix/bsd/netbsdlike/openbsd/mod.rs:    pub const fn major(dev: crate::dev_t) -> c_uint {
./src/unix/bsd/apple/mod.rs:    pub const fn major(dev: dev_t) -> i32 {
./src/unix/bsd/freebsdlike/dragonfly/mod.rs:    pub const fn major(dev: crate::dev_t) -> c_int {
./src/unix/bsd/freebsdlike/freebsd/freebsd14/mod.rs:    pub const fn major(dev: crate::dev_t) -> c_int {
./src/unix/bsd/freebsdlike/freebsd/freebsd11/mod.rs:    pub const fn major(dev: crate::dev_t) -> c_int {
./src/unix/bsd/freebsdlike/freebsd/freebsd12/mod.rs:    pub const fn major(dev: crate::dev_t) -> c_int {
./src/unix/bsd/freebsdlike/freebsd/freebsd13/mod.rs:    pub const fn major(dev: crate::dev_t) -> c_int {
./src/unix/bsd/freebsdlike/freebsd/freebsd15/mod.rs:    pub const fn major(dev: crate::dev_t) -> c_int {
./src/unix/cygwin/mod.rs:    pub const fn major(dev: dev_t) -> c_uint {
./src/unix/nto/mod.rs:    pub const fn major(dev: crate::dev_t) -> c_uint {
./src/unix/linux_like/emscripten/mod.rs:    pub const fn major(dev: crate::dev_t) -> c_uint {
./src/unix/linux_like/linux_l4re_shared.rs:    pub const fn major(dev: crate::dev_t) -> c_uint {
./src/unix/linux_like/android/mod.rs:    pub const fn major(dev: crate::dev_t) -> c_int {
./src/unix/aix/mod.rs:    pub const fn major(dev: crate::dev_t) -> c_uint {
./src/unix/hurd/mod.rs:    pub const fn major(dev: crate::dev_t) -> c_uint {
```

## Testing & Validation

Added test: `test_fill_missing_info_block_device_large_major_minor`,
This fix also makes my nvidia gpu work in my container :  )
