### PR TITLE
feat: Bring rust lib and app to parity with the v1.1.0 spec and go tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ target/
 
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
+
+# Plans from AI agents don't need to be committed
+docs/
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+This is the Rust implementation of the Container Device Interface. Library code
+lives under `src/`, with the public module surface declared in `src/lib.rs`.
+Core CDI behavior is split across `src/cache.rs`, `src/device.rs`,
+`src/spec.rs`, `src/parser.rs`, and `src/container_edits.rs`. Versioned spec
+types live in `src/specs/`, generated-spec helpers are in `src/generate/`, and
+the built-in JSON schema lives in `src/schema/schema.json` plus
+`src/schema/defs.json`. CLI entry points are `src/bin/cdi.rs` and
+`src/bin/validate.rs`; integration tests and CDI fixture YAMLs are under
+`tests/`.
+
+## Build, Test, and Formatting Commands
+
+- `cargo build --all-targets`: build the library and both binaries.
+- `cargo test`: run unit and integration tests.
+- `cargo test --test validate_cli`: focus on validator CLI/schema behavior.
+- `cargo fmt --all -- --check`: check formatting; use `cargo fmt --all` to fix.
+- `cargo clippy --all-targets --all-features -- -D warnings`: match CI linting.
+
+## Schema Sync With The Main CDI Repo
+
+The canonical schema source is the upstream CDI repo, located at:
+`https://github.com/cncf-tags/container-device-interface.git`.
+
+Copy `schema.json` and `defs.json` together; `src/schema/mod.rs` rewrites
+`defs.json#/definitions/...` references into inline definitions when compiling
+the built-in schema. After syncing, reconcile any spec-type or version-gate
+changes in `src/specs/config.rs`, `src/specs/oci.rs`, and `src/version.rs`, then
+run `cargo test --test validate_cli` and `cargo test schema`.
+
+## Coding Style & Contribution Notes
+
+Use standard Rust 2021 style and keep serde field names aligned with the CDI
+schema. Prefer typed serde parsing and validation helpers over ad hoc JSON/YAML
+string handling. For schema-facing changes, add or update fixtures in
+`tests/fixtures/` and keep CLI coverage in `tests/validate_cli.rs`. Follow
+`CONTRIBUTING.md` for review norms and sign commits with `git commit -s`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -61,7 +67,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -72,7 +78,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -92,6 +98,29 @@ name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
 
 [[package]]
 name = "base64"
@@ -143,6 +172,18 @@ name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
+name = "cc"
+version = "1.2.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
+dependencies = [
+ "find-msvc-tools",
+ "jobserver",
+ "libc",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -197,10 +238,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "const_format"
@@ -225,7 +285,7 @@ dependencies = [
 
 [[package]]
 name = "container-device-interface"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -245,6 +305,22 @@ dependencies = [
  "serde_yaml",
  "tempfile",
 ]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "darling"
@@ -280,6 +356,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "derive_builder"
@@ -330,6 +412,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "email_address"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,14 +439,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "fancy-regex"
-version = "0.16.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
 dependencies = [
  "bit-set",
  "regex-automata",
@@ -372,10 +460,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
-name = "fluent-uri"
-version = "0.3.2"
+name = "find-msvc-tools"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1918b65d96df47d3591bed19c5cca17e3fa5d0707318e4b5ef2eae01764df7e5"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
 dependencies = [
  "borrow-or-share",
  "ref-cast",
@@ -387,6 +481,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -406,6 +506,12 @@ dependencies = [
  "lazy_static",
  "num",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures-channel"
@@ -458,14 +564,27 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -488,6 +607,36 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
 ]
 
 [[package]]
@@ -551,6 +700,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -559,6 +709,21 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -700,7 +865,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -722,6 +887,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -734,29 +958,40 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.33.0"
+version = "0.46.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d46662859bc5f60a145b75f4632fbadc84e829e45df6c5de74cfc8e05acb96b5"
+checksum = "f0a699d3e77675e6aa4bfffe3b907c8b5f7ed3241f9965bffb25475ad4b08d05"
 dependencies = [
  "ahash",
- "base64",
  "bytecount",
+ "data-encoding",
  "email_address",
  "fancy-regex",
  "fraction",
+ "getrandom 0.3.4",
  "idna",
  "itoa",
+ "jsonschema-regex",
  "num-cmp",
  "num-traits",
- "once_cell",
  "percent-encoding",
  "referencing",
  "regex",
- "regex-syntax",
  "reqwest",
+ "rustls",
  "serde",
  "serde_json",
+ "unicode-general-category",
  "uuid-simd",
+]
+
+[[package]]
+name = "jsonschema-regex"
+version = "0.46.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbd1086b01b9349fd4ef9a07433965af64c8ce8159abe633a189e4ff817bd13"
+dependencies = [
+ "regex-syntax",
 ]
 
 [[package]]
@@ -820,6 +1055,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "micromap"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
+
+[[package]]
 name = "mio"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -827,7 +1068,7 @@ checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -950,6 +1191,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -995,6 +1242,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "potential_utf"
@@ -1076,13 +1329,16 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.33.0"
+version = "0.46.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e9c261f7ce75418b3beadfb3f0eb1299fe8eb9640deba45ffa2cb783098697d"
+checksum = "0fbf332a2f81899f6836f22c03da73dae8a664c32e3016b84692c23cddadc95d"
 dependencies = [
  "ahash",
  "fluent-uri",
- "once_cell",
+ "getrandom 0.3.4",
+ "hashbrown 0.16.1",
+ "itoa",
+ "micromap",
  "parking_lot",
  "percent-encoding",
  "serde_json",
@@ -1119,29 +1375,34 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
- "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -1149,6 +1410,29 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
 ]
 
 [[package]]
@@ -1161,7 +1445,81 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+dependencies = [
+ "aws-lc-rs",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1177,10 +1535,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -1232,18 +1631,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1255,6 +1642,28 @@ dependencies = [
  "serde",
  "unsafe-libyaml",
 ]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -1275,7 +1684,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1307,6 +1716,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1349,7 +1764,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1388,11 +1803,35 @@ version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
+ "bytes",
  "libc",
  "mio",
  "pin-project-lite",
  "socket2",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -1466,6 +1905,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1482,6 +1927,12 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -1508,23 +1959,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
-name = "uuid"
-version = "1.23.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "uuid-simd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
 dependencies = [
  "outref",
- "uuid",
  "vsimd",
 ]
 
@@ -1539,6 +1979,16 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -1630,10 +2080,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1643,6 +2120,70 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"
@@ -1725,6 +2266,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "container-device-interface"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "CDI (Container Device Interface), is a specification, for container-runtimes, to support third-party devices."
@@ -9,6 +9,7 @@ homepage = "https://github.com/cncf-tags/container-device-interface"
 readme = "README.md"
 categories = ["command-line-utilities"]
 keywords = ["container"]
+rust-version = "1.86.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
@@ -27,23 +28,23 @@ path = "src/bin/validate.rs" # Path to the source file
 [dependencies]
 oci-spec = { version = "0.10.0", features = ["runtime"] }
 anyhow = "1.0"
-clap = { version = "4.5.4", features = ["derive"] }
+clap = { version = "4.6.1", features = ["derive"] }
 serde_json = "1.0"
-jsonschema = "0.33.0"
-once_cell = "1.8.0"
-serde = { version = "1.0.131", features = ["derive"] }
-libc = "0.2.112"
-lazy_static = "1.2"
+jsonschema = "0.46.5"
+once_cell = "1.21.4"
+serde = { version = "1.0.228", features = ["derive"] }
+libc = "0.2.186"
+lazy_static = "1.5"
 path-clean = "1.0.1"
-serde_yaml = "0.9.33"
-semver = "1.0.22"
-regex = "1.5.4"
-const_format = "0.2.32"
+serde_yaml = "0.9.34"
+semver = "1.0.28"
+regex = "1.12.3"
+const_format = "0.2.36"
 
 [dev-dependencies]
 nix = "0.31.3"
-tempfile = "3.1.0"
-pretty_assertions = "1.0.0"
+tempfile = "3.27.0"
+pretty_assertions = "1.4.1"
 
 [profile.release]
 opt-level = "z" # CLI tools and a cdylib: size beats speed

--- a/deny.toml
+++ b/deny.toml
@@ -14,9 +14,11 @@ allow = [
     "MIT",
     "MIT-0",
     "BSD-2-Clause",
+    "BSD-3-Clause",
     "ISC",
     "Zlib",
     "CC0-1.0",
+    "CDLA-Permissive-2.0",
     "Unicode-3.0",
 ]
 confidence-threshold = 0.8

--- a/src/bin/validate_ops/args.rs
+++ b/src/bin/validate_ops/args.rs
@@ -10,17 +10,19 @@ You can use validate in following ways:
 
 1.specify document file as an argument
   validate --schema <schema.json> <document.json>
-    
+
 2.pass document content through a pipe
   cat <document.json> | validate --schema <schema.json>
 
 3.input document content manually, ended with ctrl+d(or your self-defined EOF keys)
   validate --schema <schema.json>
-  [INPUT DOCUMENT CONTENT HERE]	    
+  [INPUT DOCUMENT CONTENT HERE]
+
+Use --schema none to skip schema validation.
 "
 )]
 pub struct ValidateArgs {
-    /// JSON Schema to validate against (default "builtin")
+    /// JSON Schema to validate against: "builtin", "none" to skip validation, or a schema file
     #[arg(long = "schema", default_value = "builtin")]
     pub schema: String,
     /// Document to be validated (default "-") and it's regarded as index argument

--- a/src/bin/validate_ops/handler.rs
+++ b/src/bin/validate_ops/handler.rs
@@ -1,14 +1,16 @@
-use std::io::{self, Read};
+use std::{
+    io::{self, Read},
+    path::Path,
+};
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
+use serde_json::Value;
 
 use crate::ValidateArgs;
 
 /// handle_validate is used to handle the input arguments
 pub fn handle_validate(args: ValidateArgs) -> Result<()> {
-    println!("args: {:?}", args);
-    let _doc_data = if args.document == "-" {
-        println!("Reading from <stdin>...");
+    let doc_data = if args.document == "-" {
         let mut buffer = Vec::new();
         io::stdin().read_to_end(&mut buffer)?;
         buffer
@@ -16,7 +18,50 @@ pub fn handle_validate(args: ValidateArgs) -> Result<()> {
         std::fs::read(&args.document)?
     };
 
-    // TODO:
-    // schema::validate(args.schema, &doc_data)
-    Ok(())
+    match args.schema.as_str() {
+        "builtin" => container_device_interface::schema::validate_builtin(&doc_data),
+        "none" | "" => Ok(()),
+        _ => {
+            let schema_path = Path::new(&args.schema);
+            let schema_data = std::fs::read(schema_path)?;
+            let defs_path = schema_path.with_file_name("defs.json");
+
+            if defs_path.exists() {
+                let defs_data = std::fs::read(defs_path)?;
+                let schema = container_device_interface::schema::compile_cdi_schema(
+                    &schema_data,
+                    &defs_data,
+                )?;
+                container_device_interface::schema::validate_cdi(&schema, &doc_data)
+            } else {
+                let schema_json: Value = serde_json::from_slice(&schema_data)?;
+                if refs_defs_json(&schema_json) {
+                    return Err(anyhow!(
+                        "schema {} references defs.json, but no sibling defs.json was found",
+                        schema_path.display()
+                    ));
+                }
+                let schema = jsonschema::Validator::options()
+                    .with_draft(jsonschema::Draft::Draft7)
+                    .build(&schema_json)?;
+                container_device_interface::schema::validate(&schema, &doc_data)
+            }
+        }
+    }
+}
+
+fn refs_defs_json(value: &Value) -> bool {
+    match value {
+        Value::Object(object) => {
+            object
+                .get("$ref")
+                .and_then(Value::as_str)
+                .is_some_and(|reference| {
+                    reference == "defs.json" || reference.starts_with("defs.json#")
+                })
+                || object.values().any(refs_defs_json)
+        }
+        Value::Array(values) => values.iter().any(refs_defs_json),
+        _ => false,
+    }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -294,3 +294,72 @@ impl Cache {
         HashMap::new()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        spec::new_spec,
+        specs::config::{
+            ContainerEdits as CDIContainerEdits, Device as CDIDevice, DeviceNode, IntelRdt,
+            Spec as CDISpec,
+        },
+    };
+    use oci_spec::runtime::Spec as OCISpec;
+    use std::{collections::HashMap, path::PathBuf};
+
+    #[test]
+    fn inject_devices_preserves_spec_level_intel_rdt_with_device_edits() {
+        let raw = CDISpec {
+            version: "1.1.0".to_string(),
+            kind: "vendor.com/device".to_string(),
+            container_edits: Some(CDIContainerEdits {
+                intel_rdt: Some(IntelRdt {
+                    clos_id: Some("global-class".to_string()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            devices: vec![CDIDevice {
+                name: "gpu0".to_string(),
+                container_edits: CDIContainerEdits {
+                    device_nodes: Some(vec![DeviceNode {
+                        path: "/dev/null".to_string(),
+                        r#type: Some("c".to_string()),
+                        major: Some(1),
+                        minor: Some(3),
+                        ..Default::default()
+                    }]),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let spec = new_spec(&raw, &PathBuf::from("/tmp/vendor-device.yaml"), 0).unwrap();
+        let device = spec.get_device("gpu0").unwrap().clone();
+        let mut devices = HashMap::new();
+        devices.insert(device.get_qualified_name(), device);
+        let mut cache = Cache::new(Vec::new(), HashMap::new(), devices);
+        let mut oci_spec = OCISpec::default();
+
+        cache
+            .inject_devices(
+                Some(&mut oci_spec),
+                vec!["vendor.com/device=gpu0".to_string()],
+            )
+            .unwrap();
+
+        let intel_rdt = oci_spec
+            .linux()
+            .as_ref()
+            .unwrap()
+            .intel_rdt()
+            .as_ref()
+            .unwrap();
+        assert_eq!(
+            Some(&"global-class".to_string()),
+            intel_rdt.clos_id().as_ref()
+        );
+    }
+}

--- a/src/container_edits.rs
+++ b/src/container_edits.rs
@@ -498,6 +498,10 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "miri's stat shim does not populate rdev; /dev/null major/minor read as 0"
+    )]
     fn fill_missing_info_treats_empty_device_type_as_unset() {
         let mut device = DeviceNode {
             node: CDIDeviceNode {

--- a/src/container_edits.rs
+++ b/src/container_edits.rs
@@ -8,20 +8,27 @@ use crate::{
     generate::config::Generator,
     specs::config::{
         ContainerEdits as CDIContainerEdits, DeviceNode as CDIDeviceNode, Hook as CDIHook,
-        IntelRdt as CDIIntelRdt, Mount as CDIMount,
+        IntelRdt as CDIIntelRdt, LinuxNetDevice, Mount as CDIMount,
     },
     utils::merge,
 };
+
+const NO_PERMISSIONS: &str = "none";
 
 pub trait Validate {
     fn validate(&self) -> Result<()>;
 }
 
 fn validate_envs(envs: &[String]) -> Result<()> {
-    if envs.iter().any(|v| !v.contains('=')) {
-        return Err(anyhow!("invalid environment variable: {:?}", envs));
+    if let Some(env) = envs
+        .iter()
+        .find(|v| v.split_once('=').is_none_or(|(name, _)| name.is_empty()))
+    {
+        return Err(anyhow!(
+            "invalid environment variable {:?}: missing '=' or empty variable name",
+            env
+        ));
     }
-
     Ok(())
 }
 
@@ -66,27 +73,30 @@ impl ContainerEdits {
 
                 let d = &dn.node;
                 let mut dev = dn.node.to_oci()?;
-                if let Some(process) = oci_spec.process_mut() {
-                    let user = process.user_mut();
-                    let gid = user.gid();
-                    if gid > 0 {
-                        dev.set_gid(Some(gid));
+                if dev.uid().is_none() {
+                    if let Some(process) = oci_spec.process() {
+                        let uid = process.user().uid();
+                        if uid > 0 {
+                            dev.set_uid(Some(uid));
+                        }
                     }
-
-                    let uid = user.uid();
-                    if uid > 0 {
-                        dev.set_gid(Some(uid));
+                }
+                if dev.gid().is_none() {
+                    if let Some(process) = oci_spec.process() {
+                        let gid = process.user().gid();
+                        if gid > 0 {
+                            dev.set_gid(Some(gid));
+                        }
                     }
                 }
 
                 let dev_typ = dev.typ();
                 let typs = [LinuxDeviceType::B, LinuxDeviceType::C];
                 if typs.contains(&dev_typ) {
-                    let perms = "rwm".to_owned();
-                    let dev_access = if let Some(permissions) = &d.permissions {
-                        permissions
-                    } else {
-                        &perms
+                    let dev_access = match d.permissions.as_deref() {
+                        None | Some("") => Some("rwm".to_string()),
+                        Some(NO_PERMISSIONS) => Some(String::new()),
+                        Some(permissions) => Some(permissions.to_string()),
                     };
 
                     let major = dev.major();
@@ -96,12 +106,21 @@ impl ContainerEdits {
                         dev_typ,
                         Some(major),
                         Some(minor),
-                        Some(dev_access.clone()),
+                        dev_access,
                     );
                 }
 
                 spec_gen.remove_device(&dev.path().display().to_string());
                 spec_gen.add_device(dev.clone());
+            }
+        }
+
+        if let Some(net_devices) = &self.container_edits.net_devices {
+            for net_device in net_devices {
+                spec_gen.add_linux_net_device(
+                    net_device.host_interface_name.clone(),
+                    net_device.to_oci()?,
+                );
             }
         }
 
@@ -128,10 +147,7 @@ impl ContainerEdits {
         }
 
         if let Some(intel_rdt) = &self.container_edits.intel_rdt {
-            if let Some(clos_id) = &intel_rdt.clos_id {
-                spec_gen.set_linux_intel_rdt_clos_id(clos_id.to_string());
-                // TODO: spec.Linux.IntelRdt = e.IntelRdt.ToOCI()
-            }
+            spec_gen.set_linux_intel_rdt(intel_rdt.to_oci()?);
         }
 
         if let Some(additional_gids) = &self.container_edits.additional_gids {
@@ -155,17 +171,20 @@ impl ContainerEdits {
 
     // append other edits into this one.
     pub fn append(&mut self, o: ContainerEdits) -> Result<()> {
-        let intel_rdt = if o.container_edits.intel_rdt.is_some() {
-            o.container_edits.intel_rdt
-        } else {
-            None
-        };
+        let intel_rdt = o
+            .container_edits
+            .intel_rdt
+            .or_else(|| self.container_edits.intel_rdt.take());
 
         let ce = CDIContainerEdits {
             env: merge(&mut self.container_edits.env, &o.container_edits.env),
             device_nodes: merge(
                 &mut self.container_edits.device_nodes,
                 &o.container_edits.device_nodes,
+            ),
+            net_devices: merge(
+                &mut self.container_edits.net_devices,
+                &o.container_edits.net_devices,
             ),
             hooks: merge(&mut self.container_edits.hooks, &o.container_edits.hooks),
             mounts: merge(&mut self.container_edits.mounts, &o.container_edits.mounts),
@@ -180,6 +199,20 @@ impl ContainerEdits {
 
         Ok(())
     }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        option_vec_empty(&self.container_edits.env)
+            && option_vec_empty(&self.container_edits.device_nodes)
+            && option_vec_empty(&self.container_edits.net_devices)
+            && option_vec_empty(&self.container_edits.hooks)
+            && option_vec_empty(&self.container_edits.mounts)
+            && self.container_edits.intel_rdt.is_none()
+            && option_vec_empty(&self.container_edits.additional_gids)
+    }
+}
+
+fn option_vec_empty<T>(value: &Option<Vec<T>>) -> bool {
+    value.as_ref().is_none_or(Vec::is_empty)
 }
 
 // Validate container edits.
@@ -218,9 +251,40 @@ impl Validate for ContainerEdits {
                 .validate()
                 .context(format!("invalid container edits with mount: {:?}", irdt))?;
         }
+        if let Some(net_devices) = &self.container_edits.net_devices {
+            validate_net_devices(net_devices)?;
+        }
 
         Ok(())
     }
+}
+
+fn validate_net_devices(devices: &[LinuxNetDevice]) -> Result<()> {
+    let mut host_seen = HashSet::new();
+    let mut name_seen = HashSet::new();
+
+    for dev in devices {
+        if dev.host_interface_name.is_empty() {
+            return Err(anyhow!("invalid linux net device, empty HostInterfaceName"));
+        }
+        if dev.name.is_empty() {
+            return Err(anyhow!("invalid linux net device, empty Name"));
+        }
+        if !host_seen.insert(dev.host_interface_name.clone()) {
+            return Err(anyhow!(
+                "invalid linux net device, duplicate HostInterfaceName {:?}",
+                dev.host_interface_name
+            ));
+        }
+        if !name_seen.insert(dev.name.clone()) {
+            return Err(anyhow!(
+                "invalid linux net device, duplicate Name {:?}",
+                dev.name
+            ));
+        }
+    }
+
+    Ok(())
 }
 
 // DeviceNode is a CDI Spec DeviceNode wrapper, used for validating DeviceNodes.
@@ -235,6 +299,10 @@ impl DeviceNode {
             .host_path
             .as_deref()
             .unwrap_or_else(|| &self.node.path);
+
+        if self.node.r#type.as_deref() == Some("") {
+            self.node.r#type = None;
+        }
 
         if let Some(device_type) = self.node.r#type.as_deref() {
             if self.node.major.is_some() || device_type == DeviceType::Fifo.to_string() {
@@ -278,7 +346,7 @@ impl Validate for DeviceNode {
         }
 
         if let Some(typ) = &self.node.r#type {
-            if valid_typs.contains(&typ.as_str()) {
+            if !valid_typs.contains(typ.as_str()) {
                 return Err(anyhow!(
                     "device {:?}: invalid type {:?}",
                     self.node.path,
@@ -288,12 +356,16 @@ impl Validate for DeviceNode {
         }
 
         if let Some(perms) = &self.node.permissions {
-            if !perms.chars().all(|c| matches!(c, 'r' | 'w' | 'm')) {
-                return Err(anyhow!(
-                    "device {}: invalid permissions {}",
-                    self.node.path,
-                    perms
-                ));
+            match perms.as_str() {
+                "" | NO_PERMISSIONS => {}
+                _ if perms.chars().all(|c| matches!(c, 'r' | 'w' | 'm')) => {}
+                _ => {
+                    return Err(anyhow!(
+                        "device {}: invalid permissions {}",
+                        self.node.path,
+                        perms
+                    ));
+                }
             }
         }
 
@@ -385,5 +457,158 @@ impl Validate for IntelRdt {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::specs::config::{
+        ContainerEdits as CDIContainerEdits, DeviceNode as CDIDeviceNode, IntelRdt, LinuxNetDevice,
+    };
+    use oci_spec::runtime::{Process, Spec};
+
+    #[test]
+    fn validates_env_requires_name_and_separator() {
+        validate_envs(&["FOO=bar".to_string(), "EMPTY=".to_string()]).unwrap();
+
+        let missing_separator = validate_envs(&["FOO".to_string()]).unwrap_err();
+        assert!(missing_separator.to_string().contains("missing '='"));
+
+        let empty_name = validate_envs(&["=bar".to_string()]).unwrap_err();
+        assert!(empty_name.to_string().contains("empty variable name"));
+    }
+
+    #[test]
+    fn validates_device_type_and_permissions() {
+        let valid = CDIDeviceNode {
+            path: "/dev/example".to_string(),
+            r#type: Some("c".to_string()),
+            permissions: Some("none".to_string()),
+            ..Default::default()
+        };
+        assert!(DeviceNode { node: valid }.validate().is_ok());
+
+        let invalid_type = CDIDeviceNode {
+            path: "/dev/example".to_string(),
+            r#type: Some("bad".to_string()),
+            ..Default::default()
+        };
+        assert!(DeviceNode { node: invalid_type }.validate().is_err());
+    }
+
+    #[test]
+    fn fill_missing_info_treats_empty_device_type_as_unset() {
+        let mut device = DeviceNode {
+            node: CDIDeviceNode {
+                path: "/dev/null".to_string(),
+                r#type: Some(String::new()),
+                ..Default::default()
+            },
+        };
+
+        device.fill_missing_info().unwrap();
+
+        assert_eq!(Some("c"), device.node.r#type.as_deref());
+        assert_eq!(Some(1), device.node.major);
+        assert_eq!(Some(3), device.node.minor);
+    }
+
+    #[test]
+    fn validates_net_device_duplicates() {
+        let edits = ContainerEdits {
+            container_edits: CDIContainerEdits {
+                net_devices: Some(vec![
+                    LinuxNetDevice {
+                        host_interface_name: "eth0".to_string(),
+                        name: "container_eth0".to_string(),
+                    },
+                    LinuxNetDevice {
+                        host_interface_name: "eth0".to_string(),
+                        name: "container_eth1".to_string(),
+                    },
+                ]),
+                ..Default::default()
+            },
+        };
+
+        assert!(edits.validate().is_err());
+    }
+
+    #[test]
+    fn apply_sets_net_devices_and_full_intel_rdt() {
+        let mut spec = Spec::default();
+        let mut edits = ContainerEdits {
+            container_edits: CDIContainerEdits {
+                net_devices: Some(vec![LinuxNetDevice {
+                    host_interface_name: "eth0".to_string(),
+                    name: "container_eth0".to_string(),
+                }]),
+                intel_rdt: Some(IntelRdt {
+                    clos_id: Some("class-a".to_string()),
+                    schemata: Some(vec!["L3:0=ffff".to_string()]),
+                    enable_monitoring: Some(true),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+        };
+
+        edits.apply(&mut spec).unwrap();
+
+        let linux = spec.linux().as_ref().unwrap();
+        assert_eq!(
+            linux
+                .net_devices()
+                .as_ref()
+                .unwrap()
+                .get("eth0")
+                .unwrap()
+                .name()
+                .as_ref()
+                .unwrap(),
+            "container_eth0"
+        );
+        let rdt = linux.intel_rdt().as_ref().unwrap();
+        assert_eq!(Some(&"class-a".to_string()), rdt.clos_id().as_ref());
+        assert_eq!(
+            Some(&vec!["L3:0=ffff".to_string()]),
+            rdt.schemata().as_ref()
+        );
+        assert_eq!(Some(true), *rdt.enable_monitoring());
+    }
+
+    #[test]
+    fn apply_uses_process_uid_and_gid_only_when_device_owner_unset() {
+        let mut spec = Spec::default();
+        spec.set_process(Some(Process::default()));
+        spec.process_mut()
+            .as_mut()
+            .unwrap()
+            .user_mut()
+            .set_uid(1234);
+        spec.process_mut()
+            .as_mut()
+            .unwrap()
+            .user_mut()
+            .set_gid(5678);
+
+        let mut edits = ContainerEdits {
+            container_edits: CDIContainerEdits {
+                device_nodes: Some(vec![CDIDeviceNode {
+                    path: "/dev/null".to_string(),
+                    r#type: Some("c".to_string()),
+                    major: Some(1),
+                    minor: Some(3),
+                    ..Default::default()
+                }]),
+                ..Default::default()
+            },
+        };
+
+        edits.apply(&mut spec).unwrap();
+        let dev = &spec.linux().as_ref().unwrap().devices().as_ref().unwrap()[0];
+        assert_eq!(Some(1234), dev.uid());
+        assert_eq!(Some(5678), dev.gid());
     }
 }

--- a/src/device.rs
+++ b/src/device.rs
@@ -72,8 +72,7 @@ impl Device {
     }
     // apply_edits applies the device-speific container edits to an OCI Spec.
     pub fn apply_edits(&mut self, oci_spec: &mut oci::Spec) -> Result<()> {
-        let _ = self.edits().apply(oci_spec);
-
+        self.edits().apply(oci_spec)?;
         Ok(())
     }
 
@@ -94,6 +93,9 @@ impl Device {
         }
 
         let edits = self.edits();
+        if edits.is_empty() {
+            return Err(anyhow!("invalid device, empty device edits"));
+        }
         edits
             .validate()
             .context(format!("invalid device {:?} ", self.cdi_device.name))?;

--- a/src/generate/config.rs
+++ b/src/generate/config.rs
@@ -65,6 +65,16 @@ impl Generator {
         }
     }
 
+    pub fn init_config_linux_net_devices(&mut self) {
+        self.init_config_linux();
+
+        if let Some(linux) = self.config.as_mut().unwrap().linux_mut() {
+            if linux.net_devices().is_none() {
+                linux.set_net_devices(Some(HashMap::new()));
+            }
+        }
+    }
+
     pub fn init_config_hooks(&mut self) {
         self.init_config();
 

--- a/src/generate/generator.rs
+++ b/src/generate/generator.rs
@@ -1,7 +1,9 @@
 use std::cmp::Ordering;
 use std::path::PathBuf;
 
-use oci_spec::runtime::{Hook, LinuxDevice, LinuxDeviceCgroup, LinuxDeviceType, Mount};
+use oci_spec::runtime::{
+    Hook, LinuxDevice, LinuxDeviceCgroup, LinuxDeviceType, LinuxIntelRdt, LinuxNetDevice, Mount,
+};
 
 use super::config::Generator;
 
@@ -64,6 +66,26 @@ impl Generator {
         }
     }
 
+    pub fn add_linux_net_device(
+        &mut self,
+        host_interface_name: String,
+        net_device: LinuxNetDevice,
+    ) {
+        self.init_config_linux_net_devices();
+        if let Some(linux) = self.config.as_mut().unwrap().linux_mut() {
+            if let Some(net_devices) = linux.net_devices_mut() {
+                net_devices.insert(host_interface_name, net_device);
+            }
+        }
+    }
+
+    pub fn set_linux_intel_rdt(&mut self, intel_rdt: LinuxIntelRdt) {
+        self.init_config_linux();
+        if let Some(linux) = self.config.as_mut().unwrap().linux_mut() {
+            linux.set_intel_rdt(Some(intel_rdt));
+        }
+    }
+
     /// set Linux Intel RDT ClosID
     pub fn set_linux_intel_rdt_clos_id(&mut self, clos_id: String) {
         self.init_config_linux_intel_rdt();
@@ -78,14 +100,11 @@ impl Generator {
     pub fn add_process_additional_gid(&mut self, gid: u32) {
         self.init_config_process();
         if let Some(process) = self.config.as_mut().unwrap().process_mut() {
-            if let Some(additional_gids) = process.user().additional_gids() {
-                let mut tmp_vec = additional_gids.clone();
-                if !additional_gids.contains(&gid) {
-                    tmp_vec.push(gid)
-                }
-
-                process.user_mut().set_additional_gids(Some(tmp_vec));
+            let mut gids = process.user().additional_gids().clone().unwrap_or_default();
+            if !gids.contains(&gid) {
+                gids.push(gid);
             }
+            process.user_mut().set_additional_gids(Some(gids));
         }
     }
 
@@ -265,3 +284,53 @@ impl PartialEq for OrderedMounts {
 }
 
 impl Eq for OrderedMounts {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use oci_spec::runtime::LinuxNetDevice;
+
+    #[test]
+    fn add_process_additional_gid_initializes_empty_gid_list() {
+        let mut generator = Generator::spec_gen(Some(oci_spec::runtime::Spec::default()));
+
+        generator.add_process_additional_gid(1000);
+
+        let gids = generator
+            .config
+            .as_ref()
+            .unwrap()
+            .process()
+            .as_ref()
+            .unwrap()
+            .user()
+            .additional_gids()
+            .as_ref()
+            .unwrap();
+        assert_eq!(gids, &vec![1000]);
+    }
+
+    #[test]
+    fn add_linux_net_device_initializes_map_and_sets_entry() {
+        let mut generator = Generator::spec_gen(Some(oci_spec::runtime::Spec::default()));
+        let mut net_device = LinuxNetDevice::default();
+        net_device.set_name(Some("container_eth0".to_string()));
+
+        generator.add_linux_net_device("eth0".to_string(), net_device);
+
+        let net_devices = generator
+            .config
+            .as_ref()
+            .unwrap()
+            .linux()
+            .as_ref()
+            .unwrap()
+            .net_devices()
+            .as_ref()
+            .unwrap();
+        assert_eq!(
+            net_devices.get("eth0").unwrap().name().as_ref().unwrap(),
+            "container_eth0"
+        );
+    }
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -134,12 +134,22 @@ pub(crate) fn validate_vendor_or_class_name(name: &str) -> Result<()> {
     if name.is_empty() {
         return Err(anyhow!("empty name"));
     }
-    if !name.chars().next().unwrap_or_default().is_alphabetic() {
+    if !name.chars().next().is_some_and(|c| c.is_ascii_alphabetic()) {
         return Err(anyhow!("name should start with a letter"));
     }
+    if !name
+        .chars()
+        .last()
+        .is_some_and(|c| c.is_ascii_alphanumeric())
+    {
+        return Err(anyhow!("name should end with a letter or digit"));
+    }
+    let char_count = name.chars().count();
     if let Some(c) = name
         .chars()
-        .find(|&c| !c.is_alphanumeric() && c != '-' && c != '_' && c != '.')
+        .skip(1)
+        .take(char_count.saturating_sub(2))
+        .find(|&c| !c.is_ascii_alphanumeric() && c != '-' && c != '_' && c != '.')
     {
         return Err(anyhow!("invalid character '{}' in name {}", c, name));
     }
@@ -155,9 +165,26 @@ pub(crate) fn validate_device_name(name: &str) -> Result<()> {
     if name.is_empty() {
         return Err(anyhow!("empty name"));
     }
+    if !name
+        .chars()
+        .next()
+        .is_some_and(|c| c.is_ascii_alphanumeric())
+    {
+        return Err(anyhow!("name should start with a letter or digit"));
+    }
+    if !name
+        .chars()
+        .last()
+        .is_some_and(|c| c.is_ascii_alphanumeric())
+    {
+        return Err(anyhow!("name should end with a letter or digit"));
+    }
+    let char_count = name.chars().count();
     if let Some(c) = name
         .chars()
-        .find(|&c| !c.is_alphanumeric() && c != '-' && c != '_' && c != '.' && c != ':')
+        .skip(1)
+        .take(char_count.saturating_sub(2))
+        .find(|&c| !c.is_ascii_alphanumeric() && c != '-' && c != '_' && c != '.' && c != ':')
     {
         return Err(anyhow!("invalid character '{}' in device name {}", c, name));
     }
@@ -244,5 +271,14 @@ mod tests {
 
         let name = "nvi((dia.com";
         assert!(parser::validate_vendor_or_class_name(name).is_err());
+    }
+
+    #[test]
+    fn validate_names_require_alphanumeric_endpoints() {
+        assert!(parser::validate_vendor_name("vendor.com").is_ok());
+        assert!(parser::validate_vendor_name("vendor.").is_err());
+        assert!(parser::validate_class_name("gpu-").is_err());
+        assert!(parser::validate_device_name("_gpu").is_err());
+        assert!(parser::validate_device_name("gpu_").is_err());
     }
 }

--- a/src/schema/defs.json
+++ b/src/schema/defs.json
@@ -26,6 +26,9 @@
         "Env": {
             "$ref": "#/definitions/ArrayOfStrings"
         },
+        "InterfaceName": {
+            "type": "string"
+        },
         "mapStringString": {
             "type": "object",
             "patternProperties": {
@@ -111,6 +114,21 @@
                 "path"
             ]
         },
+        "LinuxNetDevice": {
+            "type": "object",
+            "properties": {
+                "hostInterfaceName": {
+                    "$ref": "#/definitions/InterfaceName"
+                },
+                "name": {
+                    "$ref": "#/definitions/InterfaceName"
+                }
+            },
+            "required": [
+                "hostInterfaceName",
+                "name"
+            ]
+        },
         "containerEdits": {
             "type": "object",
             "properties": {
@@ -124,6 +142,12 @@
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/DeviceNode"
+                    }
+                },
+                "netDevices": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/LinuxNetDevice"
                     }
                 },
                 "mounts": {
@@ -150,10 +174,10 @@
                         "memBwSchema": {
                             "type": "string"
                         },
-                        "enableCMT": {
-                            "type": "boolean"
+                        "schemata": {
+                            "$ref": "#/definitions/ArrayOfStrings"
                         },
-                        "enableMBM": {
+                        "enableMonitoring": {
                             "type": "boolean"
                         }
                     }

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -1,74 +1,299 @@
-use anyhow::Ok;
-// use core::panic;
-// use jsonschema::Draft;
-// use jsonschema::Validator;
-// use serde_json::json;
-// use serde_json::Value;
+use std::collections::BTreeMap;
 
-use anyhow::Result;
+use anyhow::{anyhow, Context, Result};
+use jsonschema::{Draft, Validator};
+use once_cell::sync::Lazy;
+use serde_json::Value;
 
-const _SCHEMA_JSON: &str = include_str!("schema.json");
-const _DEFS_JSON: &str = include_str!("defs.json");
+use crate::{
+    internal::validation::validate::validate_spec_annotations, specs::config::Spec as CDISpec,
+    version::validate_declared_version_fields,
+};
 
-pub fn validate(_schema: &jsonschema::Validator, _doc_data: &[u8]) -> Result<()> {
-    let mut schema_json: serde_json::Value = serde_json::from_str(include_str!("schema.json"))?;
-    let defs_json: serde_json::Value = serde_json::from_str(include_str!("defs.json"))?;
+const SCHEMA_JSON: &str = include_str!("schema.json");
+const DEFS_JSON: &str = include_str!("defs.json");
+static BUILTIN_SCHEMA: Lazy<Result<Validator, String>> =
+    Lazy::new(|| compile_builtin_schema().map_err(|err| format!("{err:#}")));
 
-    // Merge the definitions into the main schema under the "definitions" key
-    if let Some(obj) = schema_json.as_object_mut() {
-        obj.insert("definitions".to_string(), defs_json);
+pub fn builtin_schema_value() -> Result<Value> {
+    cdi_schema_value(SCHEMA_JSON.as_bytes(), DEFS_JSON.as_bytes())
+}
+
+pub fn cdi_schema_value(schema_data: &[u8], defs_data: &[u8]) -> Result<Value> {
+    let mut schema_json: Value =
+        serde_json::from_slice(schema_data).context("parse CDI schema.json")?;
+    let defs_json: Value = serde_json::from_slice(defs_data).context("parse CDI defs.json")?;
+    rewrite_defs_json_refs(&mut schema_json);
+
+    let schema = schema_json
+        .as_object_mut()
+        .ok_or_else(|| anyhow!("CDI schema must be a JSON object"))?;
+    let definitions = defs_json
+        .get("definitions")
+        .cloned()
+        .ok_or_else(|| anyhow!("CDI defs.json must contain definitions"))?;
+    schema.insert("definitions".to_string(), definitions);
+
+    Ok(schema_json)
+}
+
+fn rewrite_defs_json_refs(value: &mut Value) {
+    match value {
+        Value::Object(object) => {
+            if let Some(Value::String(reference)) = object.get_mut("$ref") {
+                if let Some(definition) = reference.strip_prefix("defs.json#/definitions/") {
+                    *reference = format!("#/definitions/{definition}");
+                }
+            }
+
+            for value in object.values_mut() {
+                rewrite_defs_json_refs(value);
+            }
+        }
+        Value::Array(values) => {
+            for value in values {
+                rewrite_defs_json_refs(value);
+            }
+        }
+        _ => {}
     }
-    /*
-        let compiled_schema = Validator::options()
-            .with_draft(Draft::Draft7) // Adjust the draft version as needed
-            .compile(&schema_json)?;
-
-        let doc = &serde_json::from_slice(doc_data)?;
-
-        let result = compiled_schema.validate(doc);
-
-    */
-
-    Ok(())
 }
 
-/*
-fn validate_data(schema: &Value, data: &Value) -> Result<(), Vec<jsonschema::ValidationError>> {
-    let compiled_schema = Validator::options()
-        .with_draft(Draft::Draft7) // Adjust the draft version as needed
-        .compile(schema)?;
-
-    compiled_schema.validate(data).map_err(|e| e.collect())
+pub fn compile_builtin_schema() -> Result<Validator> {
+    let schema_json = builtin_schema_value()?;
+    Validator::options()
+        .with_draft(Draft::Draft7)
+        .build(&schema_json)
+        .context("compile builtin CDI schema")
 }
 
+pub fn compile_cdi_schema(schema_data: &[u8], defs_data: &[u8]) -> Result<Validator> {
+    let schema_json = cdi_schema_value(schema_data, defs_data)?;
+    Validator::options()
+        .with_draft(Draft::Draft7)
+        .build(&schema_json)
+        .context("compile CDI schema")
+}
 
+pub fn document_value(doc_data: &[u8]) -> Result<Value> {
+    let yaml_value: serde_yaml::Value =
+        serde_yaml::from_slice(doc_data).context("parse CDI document")?;
+    serde_json::to_value(yaml_value).context("convert CDI document to JSON value")
+}
 
-pub fn load(schema_file: &str) -> Result<jsonschema::Validator> {
+pub fn validate(schema: &Validator, doc_data: &[u8]) -> Result<()> {
+    let doc = document_value(doc_data)?;
+    validate_value(schema, &doc)
+}
 
-    let schema_context = SchemaContext::builtin()?;
-    Ok(schema_context.compiled_schema)
-    /*
-    if schema_file == "builtin" {
-        println!("Loading schema from {}...", schema_file);
+pub fn validate_cdi(schema: &Validator, doc_data: &[u8]) -> Result<()> {
+    let doc = document_value(doc_data)?;
+    validate_value(schema, &doc)?;
+    validate_cdi_document_content(&doc)?;
+    validate_typed_cdi_document(doc_data)
+}
 
-        print!("schema:\n{}", builtin_schema);
+pub fn validate_builtin(doc_data: &[u8]) -> Result<()> {
+    let schema = BUILTIN_SCHEMA
+        .as_ref()
+        .map_err(|err| anyhow!("compile builtin CDI schema: {err}"))?;
+    validate_cdi(schema, doc_data)
+}
 
-        match jsonschema::Validator::compile(&serde_json::from_str(&builtin_schema)?) {
-            Ok(schema) => return Ok(schema),
-            Err(e) => return Err(anyhow!("failed to compile builtin schema {}", e)),
+fn validate_value(schema: &Validator, doc: &Value) -> Result<()> {
+    let errors: Vec<String> = schema
+        .iter_errors(doc)
+        .map(|error| error.to_string())
+        .collect();
+
+    if errors.is_empty() {
+        return Ok(());
+    }
+
+    Err(anyhow!("schema validation failed: {}", errors.join("; ")))
+}
+
+fn validate_typed_cdi_document(doc_data: &[u8]) -> Result<()> {
+    let spec: CDISpec =
+        serde_yaml::from_slice(doc_data).context("parse CDI document using declared version")?;
+    validate_declared_version_fields(&spec)
+}
+
+fn validate_cdi_document_content(doc: &Value) -> Result<()> {
+    if doc
+        .get("devices")
+        .and_then(Value::as_array)
+        .is_some_and(Vec::is_empty)
+    {
+        return Err(anyhow!(
+            "CDI schema validation failed: top-level devices array must not be empty"
+        ));
+    }
+
+    validate_annotations("", doc.get("annotations"))?;
+
+    if let Some(devices) = doc.get("devices").and_then(Value::as_array) {
+        for device in devices {
+            let name = device
+                .get("name")
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            validate_annotations(name, device.get("annotations"))?;
         }
     }
-    */
-    //panic!("not implemented yet loading from other sources")
+
+    Ok(())
 }
 
+fn validate_annotations(name: &str, annotations: Option<&Value>) -> Result<()> {
+    let Some(Value::Object(annotations)) = annotations else {
+        return Ok(());
+    };
 
- pub fn validate(schema: &jsonschema::Validator, doc_data: &[u8]) -> Result<()> {
-    let doc = serde_json::from_slice(doc_data)?;
-    match schema.validate(&doc) {
-        Ok(_) => (),
-        Err(_e) => return Err(anyhow!("validation failed")),
+    let mut parsed = BTreeMap::new();
+    for (key, value) in annotations {
+        let Some(value) = value.as_str() else {
+            return Err(anyhow!(
+                "invalid annotation {}.{}; annotation value is not a string",
+                name,
+                key
+            ));
+        };
+        parsed.insert(key.clone(), value.to_string());
     }
-    Ok(())
+
+    validate_spec_annotations(name, &parsed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builtin_schema_accepts_v1_1_features() {
+        let doc = br#"
+cdiVersion: "1.1.0"
+kind: "vendor.com/device"
+containerEdits:
+  netDevices:
+    - hostInterfaceName: "eth0"
+      name: "container_eth0"
+  intelRdt:
+    schemata:
+      - "L3:0=ffff"
+    enableMonitoring: true
+devices:
+  - name: "gpu0"
+    containerEdits:
+      deviceNodes:
+        - path: "/dev/null"
+"#;
+
+        validate_builtin(doc).expect("v1.1.0 document should validate");
     }
-    */
+
+    #[test]
+    fn builtin_schema_rejects_wrong_type() {
+        let doc = br#"
+cdiVersion: "1.1.0"
+kind: "vendor.com/device"
+devices: "not-an-array"
+"#;
+
+        assert!(validate_builtin(doc).is_err());
+    }
+
+    #[test]
+    fn builtin_schema_rejects_v1_1_legacy_intel_rdt_fields() {
+        let doc = br#"
+cdiVersion: "1.1.0"
+kind: "vendor.com/device"
+containerEdits:
+  intelRdt:
+    enableCMT: true
+devices:
+  - name: "gpu0"
+    containerEdits:
+      deviceNodes:
+        - path: "/dev/null"
+"#;
+
+        let err = validate_builtin(doc).expect_err("v1.1.0 must reject legacy Intel RDT fields");
+
+        assert!(err.to_string().contains("enableCMT"));
+    }
+
+    #[test]
+    fn builtin_schema_rejects_v1_0_intel_rdt_enable_monitoring_field() {
+        let doc = br#"
+cdiVersion: "1.0.0"
+kind: "vendor.com/device"
+containerEdits:
+  intelRdt:
+    enableMonitoring: false
+devices:
+  - name: "gpu0"
+    containerEdits:
+      deviceNodes:
+        - path: "/dev/null"
+"#;
+
+        let err = validate_builtin(doc).expect_err("v1.0.0 must reject v1.1.0 Intel RDT fields");
+
+        assert!(err.to_string().contains("enableMonitoring"));
+    }
+
+    #[test]
+    fn generic_validate_allows_empty_devices_when_schema_allows_it() {
+        let schema_json: Value = serde_json::json!({
+            "type": "object"
+        });
+        let schema = Validator::options()
+            .with_draft(Draft::Draft7)
+            .build(&schema_json)
+            .expect("compile permissive schema");
+        let doc = br#"
+devices: []
+"#;
+
+        validate(&schema, doc).expect("generic validation should only apply the supplied schema");
+    }
+
+    #[test]
+    fn cdi_schema_rejects_invalid_spec_annotations() {
+        let doc = br#"
+cdiVersion: "1.1.0"
+kind: "vendor.com/device"
+annotations:
+  "inva$$lid_CDIKEY": "value"
+devices:
+  - name: "gpu0"
+    containerEdits:
+      deviceNodes:
+        - path: "/dev/null"
+"#;
+
+        let err = validate_builtin(doc).expect_err("invalid annotation key should fail");
+
+        assert!(err.to_string().contains("annotations"));
+    }
+
+    #[test]
+    fn cdi_schema_rejects_invalid_device_annotations() {
+        let doc = br#"
+cdiVersion: "1.1.0"
+kind: "vendor.com/device"
+devices:
+  - name: "gpu0"
+    annotations:
+      "inva$$lid_CDIKEY": "value"
+    containerEdits:
+      deviceNodes:
+        - path: "/dev/null"
+"#;
+
+        let err = validate_builtin(doc).expect_err("invalid device annotation key should fail");
+
+        assert!(err.to_string().contains("gpu0.annotations"));
+    }
+}

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, fs::File, path::PathBuf};
+use std::{collections::BTreeMap, path::PathBuf};
 
 use anyhow::{anyhow, Context, Result};
 use oci_spec::runtime as oci;
@@ -15,7 +15,10 @@ use crate::{
     parser::validate_vendor_name,
     specs::config::Spec as CDISpec,
     utils::is_cdi_spec,
-    version::{minimum_required_version, VersionWrapper, VALID_SPEC_VERSIONS},
+    version::{
+        minimum_required_version, validate_declared_version_fields, VersionWrapper,
+        VALID_SPEC_VERSIONS,
+    },
 };
 
 const DEFAULT_SPEC_EXT_SUFFIX: &str = ".yaml";
@@ -99,6 +102,10 @@ impl Spec {
             devices.insert(d.name.clone(), dev);
         }
 
+        if devices.is_empty() {
+            return Err(anyhow::anyhow!("invalid spec, no devices"));
+        }
+
         Ok(devices)
     }
 
@@ -118,16 +125,16 @@ pub fn parse_spec(path: &PathBuf) -> Result<CDISpec> {
         return Err(anyhow!("CDI spec path not found"));
     }
 
-    let config_file = File::open(path).context("open config file")?;
-    let cdi_spec: CDISpec =
-        serde_yaml::from_reader(config_file).context("serde yaml read from file")?;
+    let data = std::fs::read(path).context("read config file")?;
+    let cdi_spec: CDISpec = serde_yaml::from_slice(&data).context("serde yaml read from file")?;
 
     Ok(cdi_spec)
 }
 
 // validate_spec validates the Spec using the extneral validator.
-pub fn validate_spec(_raw_spec: &CDISpec) -> Result<()> {
-    // TODO
+pub fn validate_spec(raw_spec: &CDISpec) -> Result<()> {
+    let data = serde_yaml::to_string(raw_spec).context("marshal CDI spec for schema validation")?;
+    crate::schema::validate_builtin(data.as_bytes()).context("invalid CDI Spec schema")?;
     Ok(())
 }
 
@@ -145,6 +152,10 @@ pub fn read_spec(path: &PathBuf, priority: i32) -> Result<Spec> {
 // Spec is marked as loaded from the given path with the given
 // priority. If Spec data validation fails new_spec returns an error.
 pub fn new_spec(raw_spec: &CDISpec, path: &PathBuf, priority: i32) -> Result<Spec> {
+    if raw_spec.devices.is_empty() {
+        return Err(anyhow::anyhow!("invalid spec, no devices"));
+    }
+
     validate_spec(raw_spec).context("invalid CDI Spec")?;
 
     let mut cleaned_path = clean(path);
@@ -173,6 +184,8 @@ fn validate_version(cdi_spec: &CDISpec) -> Result<()> {
         return Err(anyhow::anyhow!("invalid version {}", version));
     }
 
+    validate_declared_version_fields(cdi_spec)?;
+
     let min_version = minimum_required_version(cdi_spec)
         .with_context(|| "could not determine minimum required version")?;
 
@@ -184,4 +197,78 @@ fn validate_version(cdi_spec: &CDISpec) -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use oci_spec::runtime as oci;
+    use std::path::PathBuf;
+
+    #[test]
+    fn parse_spec_rejects_unknown_fields() {
+        let path = PathBuf::from("tests/fixtures/cdi-unknown-field.yaml");
+        let err = parse_spec(&path).expect_err("unknown field should fail");
+        assert!(err.to_string().contains("serde yaml read from file"));
+    }
+
+    #[test]
+    fn new_spec_rejects_empty_devices() {
+        let path = PathBuf::from("tests/fixtures/cdi-empty-devices.yaml");
+        let raw = parse_spec(&path).expect("empty device fixture parses");
+        let err = new_spec(&raw, &path, 0).expect_err("empty devices should fail");
+        assert!(err.to_string().contains("no devices"));
+    }
+
+    #[test]
+    fn new_spec_rejects_legacy_intel_rdt_fields_in_v1_1() {
+        let path = PathBuf::from("tests/fixtures/cdi-v1.1-legacy-intel-rdt.yaml");
+        let raw = parse_spec(&path).expect("legacy fields should parse before version validation");
+        let err = new_spec(&raw, &path, 0).expect_err("v1.1.0 should reject legacy fields");
+
+        assert!(format!("{err:#}").contains("enableCMT"));
+    }
+
+    #[test]
+    fn new_spec_processes_legacy_intel_rdt_fields_before_v1_1() {
+        let path = PathBuf::from("tests/fixtures/cdi-v1.0-legacy-intel-rdt.yaml");
+        let raw = parse_spec(&path).expect("v1.0.0 legacy Intel RDT fixture parses");
+        let mut spec = new_spec(&raw, &path, 0).expect("v1.0.0 legacy Intel RDT fixture validates");
+        let mut oci_spec = oci::Spec::default();
+
+        spec.apply_edits(&mut oci_spec)
+            .expect("legacy Intel RDT edits apply");
+
+        let rdt = oci_spec
+            .linux()
+            .as_ref()
+            .and_then(|linux| linux.intel_rdt().as_ref())
+            .expect("Intel RDT should be set");
+
+        #[allow(deprecated)]
+        {
+            assert_eq!(&Some(true), rdt.enable_cmt());
+            assert_eq!(&Some(true), rdt.enable_mbm());
+        }
+    }
+
+    #[test]
+    fn new_spec_rejects_empty_device_edits() {
+        let raw = CDISpec {
+            version: "1.1.0".to_string(),
+            kind: "vendor.com/device".to_string(),
+            devices: vec![crate::specs::config::Device {
+                name: "gpu0".to_string(),
+                container_edits: crate::specs::config::ContainerEdits::default(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let path = PathBuf::from("/tmp/vendor-device.yaml");
+
+        let err = new_spec(&raw, &path, 0).expect_err("empty device edits should fail");
+        let err = format!("{err:?}");
+
+        assert!(err.contains("empty device edits"), "{err}");
+    }
 }

--- a/src/specs/config.rs
+++ b/src/specs/config.rs
@@ -5,10 +5,11 @@ use libc::mode_t;
 use serde::{Deserialize, Serialize};
 
 // CurrentVersion is the current version of the Spec.
-pub const CURRENT_VERSION: &str = "0.7.0";
+pub const CURRENT_VERSION: &str = "1.1.0";
 
 // Spec is the base configuration for CDI
 #[derive(Clone, Debug, Default, Eq, PartialEq, Hash, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct Spec {
     #[serde(rename = "cdiVersion")]
     pub(crate) version: String,
@@ -32,6 +33,7 @@ pub struct Spec {
 
 // Device is a "Device" a container runtime can add to a container
 #[derive(Clone, Debug, Default, Eq, PartialEq, Hash, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct Device {
     #[serde(rename = "name")]
     pub(crate) name: String,
@@ -49,12 +51,16 @@ pub struct Device {
 
 // ContainerEdits are edits a container runtime must make to the OCI spec to expose the device.
 #[derive(Clone, Debug, Default, Eq, PartialEq, Hash, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ContainerEdits {
     #[serde(rename = "env", skip_serializing_if = "Option::is_none")]
     pub env: Option<Vec<String>>,
 
     #[serde(rename = "deviceNodes", skip_serializing_if = "Option::is_none")]
     pub device_nodes: Option<Vec<DeviceNode>>,
+
+    #[serde(rename = "netDevices", skip_serializing_if = "Option::is_none")]
+    pub(crate) net_devices: Option<Vec<LinuxNetDevice>>,
 
     #[serde(rename = "hooks", skip_serializing_if = "Option::is_none")]
     pub hooks: Option<Vec<Hook>>,
@@ -71,6 +77,7 @@ pub struct ContainerEdits {
 
 // DeviceNode represents a device node that needs to be added to the OCI spec.
 #[derive(Clone, Debug, Default, Eq, PartialEq, Hash, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct DeviceNode {
     #[serde(rename = "path")]
     pub(crate) path: String,
@@ -102,6 +109,7 @@ pub struct DeviceNode {
 
 // Mount represents a mount that needs to be added to the OCI spec.
 #[derive(Clone, Debug, Default, Eq, PartialEq, Hash, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct Mount {
     #[serde(rename = "hostPath")]
     pub(crate) host_path: String,
@@ -118,6 +126,7 @@ pub struct Mount {
 
 // Hook represents a hook that needs to be added to the OCI spec.
 #[derive(Clone, Debug, Default, Eq, PartialEq, Hash, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct Hook {
     #[serde(rename = "hookName")]
     pub(crate) hook_name: String,
@@ -137,6 +146,7 @@ pub struct Hook {
 
 // IntelRdt describes the Linux IntelRdt parameters to set in the OCI spec.
 #[derive(Clone, Debug, Default, Eq, PartialEq, Hash, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct IntelRdt {
     #[serde(rename = "closID", skip_serializing_if = "Option::is_none")]
     pub(crate) clos_id: Option<String>,
@@ -147,9 +157,26 @@ pub struct IntelRdt {
     #[serde(rename = "memBwSchema", skip_serializing_if = "Option::is_none")]
     pub(crate) mem_bw_schema: Option<String>,
 
-    #[serde(default, rename = "enableCMT")]
-    pub(crate) enable_cmt: bool,
+    #[serde(rename = "schemata", skip_serializing_if = "Option::is_none")]
+    pub(crate) schemata: Option<Vec<String>>,
 
-    #[serde(default, rename = "enableMBM")]
-    pub(crate) enable_mbm: bool,
+    #[serde(rename = "enableMonitoring", skip_serializing_if = "Option::is_none")]
+    pub(crate) enable_monitoring: Option<bool>,
+
+    #[serde(rename = "enableCMT", skip_serializing_if = "Option::is_none")]
+    pub(crate) enable_cmt: Option<bool>,
+
+    #[serde(rename = "enableMBM", skip_serializing_if = "Option::is_none")]
+    pub(crate) enable_mbm: Option<bool>,
+}
+
+// LinuxNetDevice represents an OCI LinuxNetDevice to be added to the OCI Spec.
+#[derive(Clone, Debug, Default, Eq, PartialEq, Hash, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct LinuxNetDevice {
+    #[serde(rename = "hostInterfaceName")]
+    pub(crate) host_interface_name: String,
+
+    #[serde(rename = "name")]
+    pub(crate) name: String,
 }

--- a/src/specs/oci.rs
+++ b/src/specs/oci.rs
@@ -1,11 +1,14 @@
-use std::path::PathBuf;
+use std::{path::PathBuf, str::FromStr};
 
 use anyhow::Result;
 use oci_spec::runtime::{
-    Hook as OCIHook, LinuxDevice, LinuxDeviceType, LinuxIntelRdt, Mount as OCIMount,
+    Hook as OCIHook, LinuxDevice, LinuxDeviceType, LinuxIntelRdt,
+    LinuxNetDevice as OCILinuxNetDevice, Mount as OCIMount,
 };
 
-use crate::specs::config::{DeviceNode, Hook as CDIHook, IntelRdt, Mount as CDIMount};
+use crate::specs::config::{
+    DeviceNode, Hook as CDIHook, IntelRdt, LinuxNetDevice, Mount as CDIMount,
+};
 
 impl CDIHook {
     pub fn to_oci(&self) -> Result<OCIHook> {
@@ -35,12 +38,12 @@ impl DeviceNode {
     pub fn to_oci(&self) -> Result<LinuxDevice> {
         let mut linux_device: LinuxDevice = Default::default();
         linux_device.set_path(PathBuf::from(&self.path));
-        if let Some(_typ) = &self.r#type {
-            linux_device.set_typ(LinuxDeviceType::C);
+        if let Some(typ) = &self.r#type {
+            linux_device.set_typ(LinuxDeviceType::from_str(typ)?);
         }
         if let Some(maj) = self.major {
             linux_device.set_major(maj);
-        };
+        }
         if let Some(min) = self.minor {
             linux_device.set_minor(min);
         }
@@ -53,15 +56,26 @@ impl DeviceNode {
 }
 
 impl IntelRdt {
+    #[allow(deprecated)]
     pub fn to_oci(&self) -> Result<LinuxIntelRdt> {
         let mut intel_rdt: LinuxIntelRdt = Default::default();
         intel_rdt.set_clos_id(self.clos_id.clone());
         intel_rdt.set_l3_cache_schema(self.l3_cache_schema.clone());
         intel_rdt.set_mem_bw_schema(self.mem_bw_schema.clone());
-        intel_rdt.set_enable_cmt(Some(self.enable_cmt));
-        intel_rdt.set_enable_mbm(Some(self.enable_mbm));
+        intel_rdt.set_schemata(self.schemata.clone());
+        intel_rdt.set_enable_monitoring(self.enable_monitoring);
+        intel_rdt.set_enable_cmt(self.enable_cmt);
+        intel_rdt.set_enable_mbm(self.enable_mbm);
 
         Ok(intel_rdt)
+    }
+}
+
+impl LinuxNetDevice {
+    pub fn to_oci(&self) -> Result<OCILinuxNetDevice> {
+        let mut net_device = OCILinuxNetDevice::default();
+        net_device.set_name(Some(self.name.clone()));
+        Ok(net_device)
     }
 }
 
@@ -71,7 +85,7 @@ mod tests {
     use std::path::PathBuf;
 
     use crate::specs::{
-        config::DeviceNode,
+        config::{DeviceNode, IntelRdt, LinuxNetDevice},
         oci::{CDIHook, CDIMount, OCIHook, OCIMount},
     };
 
@@ -127,5 +141,67 @@ mod tests {
         assert_eq!(PathBuf::from(dev_node.path), linux_dev.path().clone());
         assert_eq!(dev_node.major, Some(linux_dev.major()));
         assert_eq!(dev_node.minor, Some(linux_dev.minor()));
+    }
+
+    #[test]
+    fn test_device_node_to_oci_preserves_type() {
+        let dev_node = DeviceNode {
+            path: "/dev/example".to_string(),
+            r#type: Some("b".to_string()),
+            major: Some(8),
+            minor: Some(0),
+            ..Default::default()
+        };
+
+        let linux_dev = dev_node.to_oci().unwrap();
+        assert_eq!(oci_spec::runtime::LinuxDeviceType::B, linux_dev.typ());
+    }
+
+    #[test]
+    fn test_intel_rdt_to_oci_v1_1_fields() {
+        let intel_rdt = IntelRdt {
+            clos_id: Some("class-a".to_string()),
+            l3_cache_schema: Some("L3:0=ffff".to_string()),
+            mem_bw_schema: Some("MB:0=100".to_string()),
+            schemata: Some(vec!["L3:0=ffff".to_string()]),
+            enable_monitoring: Some(true),
+            enable_cmt: Some(true),
+            enable_mbm: Some(true),
+        };
+
+        let oci_rdt = intel_rdt.to_oci().unwrap();
+        assert_eq!(Some(&"class-a".to_string()), oci_rdt.clos_id().as_ref());
+        assert_eq!(
+            Some(&"L3:0=ffff".to_string()),
+            oci_rdt.l3_cache_schema().as_ref()
+        );
+        assert_eq!(
+            Some(&"MB:0=100".to_string()),
+            oci_rdt.mem_bw_schema().as_ref()
+        );
+        assert_eq!(
+            Some(&vec!["L3:0=ffff".to_string()]),
+            oci_rdt.schemata().as_ref()
+        );
+        assert_eq!(&Some(true), oci_rdt.enable_monitoring());
+        #[allow(deprecated)]
+        {
+            assert_eq!(&Some(true), oci_rdt.enable_cmt());
+            assert_eq!(&Some(true), oci_rdt.enable_mbm());
+        }
+    }
+
+    #[test]
+    fn test_linux_net_device_to_oci() {
+        let net_device = LinuxNetDevice {
+            host_interface_name: "eth0".to_string(),
+            name: "container_eth0".to_string(),
+        };
+
+        let oci_net_device = net_device.to_oci().unwrap();
+        assert_eq!(
+            Some(&"container_eth0".to_string()),
+            oci_net_device.name().as_ref()
+        );
     }
 }

--- a/src/version.rs
+++ b/src/version.rs
@@ -18,6 +18,9 @@ const V040: &str = "v0.4.0";
 const V050: &str = "v0.5.0";
 const V060: &str = "v0.6.0";
 const V070: &str = "v0.7.0";
+const V080: &str = "v0.8.0";
+const V100: &str = "v1.0.0";
+const V110: &str = "v1.1.0";
 
 // Earliest supported version of the CDI specification
 const VEARLIEST: &str = V030;
@@ -36,6 +39,9 @@ pub static VALID_SPEC_VERSIONS: Lazy<VersionMap> = Lazy::new(|| {
     map.insert(V050.to_string(), Some(requires_v050));
     map.insert(V060.to_string(), Some(requires_v060));
     map.insert(V070.to_string(), Some(requires_v070));
+    map.insert(V080.to_string(), None);
+    map.insert(V100.to_string(), None);
+    map.insert(V110.to_string(), Some(requires_v110 as RequiredFunc));
     VersionMap(map)
 });
 
@@ -87,6 +93,108 @@ impl VersionWrapper {
 
 pub fn minimum_required_version(spec: &CDISpec) -> Result<VersionWrapper> {
     Ok(VALID_SPEC_VERSIONS.required_version(spec))
+}
+
+pub(crate) fn validate_declared_version_fields(spec: &CDISpec) -> Result<()> {
+    if !VALID_SPEC_VERSIONS.is_valid_version(&spec.version) {
+        return Err(anyhow::anyhow!("invalid version {}", spec.version));
+    }
+
+    let declared = VersionWrapper::new(&spec.version);
+    let v110 = VersionWrapper::new(V110);
+    let declared_is_v110_or_newer = !v110.is_greater_than(&declared);
+
+    for (scope, edits) in spec
+        .container_edits
+        .iter()
+        .map(|edits| ("containerEdits", edits))
+        .chain(
+            spec.devices
+                .iter()
+                .map(|device| ("devices[].containerEdits", &device.container_edits)),
+        )
+    {
+        if let Some(intel_rdt) = &edits.intel_rdt {
+            if declared_is_v110_or_newer {
+                if intel_rdt.enable_cmt.is_some() {
+                    return Err(anyhow::anyhow!(
+                        "{}.intelRdt.enableCMT is not valid for CDI spec version {}",
+                        scope,
+                        spec.version
+                    ));
+                }
+                if intel_rdt.enable_mbm.is_some() {
+                    return Err(anyhow::anyhow!(
+                        "{}.intelRdt.enableMBM is not valid for CDI spec version {}",
+                        scope,
+                        spec.version
+                    ));
+                }
+            } else {
+                if intel_rdt.schemata.is_some() {
+                    return Err(anyhow::anyhow!(
+                        "{}.intelRdt.schemata requires CDI spec version 1.1.0",
+                        scope
+                    ));
+                }
+                if intel_rdt.enable_monitoring.is_some() {
+                    return Err(anyhow::anyhow!(
+                        "{}.intelRdt.enableMonitoring requires CDI spec version 1.1.0",
+                        scope
+                    ));
+                }
+            }
+        }
+
+        if !declared_is_v110_or_newer
+            && edits
+                .net_devices
+                .as_ref()
+                .is_some_and(|devices| !devices.is_empty())
+        {
+            return Err(anyhow::anyhow!(
+                "{}.netDevices requires CDI spec version 1.1.0",
+                scope
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn requires_v110(spec: &CDISpec) -> bool {
+    if let Some(edits) = &spec.container_edits {
+        if edits
+            .net_devices
+            .as_ref()
+            .is_some_and(|devices| !devices.is_empty())
+        {
+            return true;
+        }
+        if let Some(intel_rdt) = &edits.intel_rdt {
+            if intel_rdt.schemata.is_some() || intel_rdt.enable_monitoring.is_some() {
+                return true;
+            }
+        }
+    }
+
+    for dev in &spec.devices {
+        let edits = &dev.container_edits;
+        if edits
+            .net_devices
+            .as_ref()
+            .is_some_and(|devices| !devices.is_empty())
+        {
+            return true;
+        }
+        if let Some(intel_rdt) = &edits.intel_rdt {
+            if intel_rdt.schemata.is_some() || intel_rdt.enable_monitoring.is_some() {
+                return true;
+            }
+        }
+    }
+
+    false
 }
 
 fn requires_v070(spec: &CDISpec) -> bool {
@@ -168,4 +276,131 @@ fn requires_v040(spec: &CDISpec) -> bool {
         .chain(spec.container_edits.as_ref())
         .flat_map(|edits| edits.mounts.iter().flat_map(|mounts| mounts.iter()))
         .any(|mount| mount.r#type.as_ref().is_some_and(|typ| !typ.is_empty()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::specs::config::{ContainerEdits, Device, IntelRdt, LinuxNetDevice, Spec};
+
+    fn spec_with_edits(version: &str, edits: ContainerEdits) -> Spec {
+        Spec {
+            version: version.to_string(),
+            kind: "vendor.com/device".to_string(),
+            devices: vec![Device {
+                name: "gpu0".to_string(),
+                container_edits: ContainerEdits::default(),
+                ..Default::default()
+            }],
+            container_edits: Some(edits),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn accepts_current_v1_1_0_version() {
+        assert!(VALID_SPEC_VERSIONS.is_valid_version("1.1.0"));
+    }
+
+    #[test]
+    fn recognizes_v0_8_and_v1_0_versions() {
+        assert!(VALID_SPEC_VERSIONS.is_valid_version("0.8.0"));
+        assert!(VALID_SPEC_VERSIONS.is_valid_version("1.0.0"));
+    }
+
+    #[test]
+    fn net_devices_require_v1_1_0() {
+        let spec = spec_with_edits(
+            "1.1.0",
+            ContainerEdits {
+                net_devices: Some(vec![LinuxNetDevice {
+                    host_interface_name: "eth0".to_string(),
+                    name: "container_eth0".to_string(),
+                }]),
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(
+            minimum_required_version(&spec).unwrap().to_string(),
+            "1.1.0"
+        );
+    }
+
+    #[test]
+    fn intel_rdt_schemata_requires_v1_1_0() {
+        let spec = spec_with_edits(
+            "1.1.0",
+            ContainerEdits {
+                intel_rdt: Some(IntelRdt {
+                    schemata: Some(vec!["L3:0=ffff".to_string()]),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(
+            minimum_required_version(&spec).unwrap().to_string(),
+            "1.1.0"
+        );
+    }
+
+    #[test]
+    fn empty_intel_rdt_schemata_requires_v1_1_0() {
+        let global_spec = spec_with_edits(
+            "1.1.0",
+            ContainerEdits {
+                intel_rdt: Some(IntelRdt {
+                    schemata: Some(Vec::new()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+        );
+        let device_spec = Spec {
+            version: "1.1.0".to_string(),
+            kind: "vendor.com/device".to_string(),
+            devices: vec![Device {
+                name: "gpu0".to_string(),
+                container_edits: ContainerEdits {
+                    intel_rdt: Some(IntelRdt {
+                        schemata: Some(Vec::new()),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        assert_eq!(
+            minimum_required_version(&global_spec).unwrap().to_string(),
+            "1.1.0"
+        );
+        assert_eq!(
+            minimum_required_version(&device_spec).unwrap().to_string(),
+            "1.1.0"
+        );
+    }
+
+    #[test]
+    fn intel_rdt_enable_monitoring_requires_v1_1_0() {
+        let spec = spec_with_edits(
+            "1.1.0",
+            ContainerEdits {
+                intel_rdt: Some(IntelRdt {
+                    enable_monitoring: Some(true),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(
+            minimum_required_version(&spec).unwrap().to_string(),
+            "1.1.0"
+        );
+    }
 }

--- a/tests/fixtures/cdi-empty-devices.yaml
+++ b/tests/fixtures/cdi-empty-devices.yaml
@@ -1,0 +1,3 @@
+cdiVersion: "1.1.0"
+kind: "vendor.com/device"
+devices: []

--- a/tests/fixtures/cdi-invalid-annotation.yaml
+++ b/tests/fixtures/cdi-invalid-annotation.yaml
@@ -1,0 +1,9 @@
+cdiVersion: "1.1.0"
+kind: "vendor.com/device"
+annotations:
+  "inva$$lid_CDIKEY": "value"
+devices:
+  - name: "gpu0"
+    containerEdits:
+      deviceNodes:
+        - path: "/dev/null"

--- a/tests/fixtures/cdi-unknown-field.yaml
+++ b/tests/fixtures/cdi-unknown-field.yaml
@@ -1,0 +1,8 @@
+cdiVersion: "1.1.0"
+kind: "vendor.com/device"
+unknownTopLevel: true
+devices:
+  - name: "gpu0"
+    containerEdits:
+      deviceNodes:
+        - path: "/dev/null"

--- a/tests/fixtures/cdi-v1.0-enable-monitoring.yaml
+++ b/tests/fixtures/cdi-v1.0-enable-monitoring.yaml
@@ -1,0 +1,10 @@
+cdiVersion: "1.0.0"
+kind: "vendor.com/device"
+containerEdits:
+  intelRdt:
+    enableMonitoring: false
+devices:
+  - name: "gpu0"
+    containerEdits:
+      deviceNodes:
+        - path: "/dev/null"

--- a/tests/fixtures/cdi-v1.0-legacy-intel-rdt.yaml
+++ b/tests/fixtures/cdi-v1.0-legacy-intel-rdt.yaml
@@ -1,0 +1,12 @@
+cdiVersion: "1.0.0"
+kind: "vendor.com/device"
+containerEdits:
+  intelRdt:
+    closID: "legacy-class"
+    enableCMT: true
+    enableMBM: true
+devices:
+  - name: "gpu0"
+    containerEdits:
+      deviceNodes:
+        - path: "/dev/null"

--- a/tests/fixtures/cdi-v1.1-good.yaml
+++ b/tests/fixtures/cdi-v1.1-good.yaml
@@ -1,0 +1,19 @@
+cdiVersion: "1.1.0"
+kind: "vendor.com/device"
+containerEdits:
+  intelRdt:
+    closID: "class-a"
+    schemata:
+      - "L3:0=ffff"
+    enableMonitoring: true
+  netDevices:
+    - hostInterfaceName: "eth0"
+      name: "container_eth0"
+devices:
+  - name: "gpu0"
+    containerEdits:
+      deviceNodes:
+        - path: "/dev/null"
+          type: "c"
+          major: 1
+          minor: 3

--- a/tests/fixtures/cdi-v1.1-legacy-intel-rdt.yaml
+++ b/tests/fixtures/cdi-v1.1-legacy-intel-rdt.yaml
@@ -1,0 +1,10 @@
+cdiVersion: "1.1.0"
+kind: "vendor.com/device"
+containerEdits:
+  intelRdt:
+    enableCMT: true
+devices:
+  - name: "gpu0"
+    containerEdits:
+      deviceNodes:
+        - path: "/dev/null"

--- a/tests/validate_cli.rs
+++ b/tests/validate_cli.rs
@@ -1,0 +1,185 @@
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+fn validate_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_validate")
+}
+
+fn manifest_path(path: impl AsRef<Path>) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(path)
+}
+
+#[test]
+fn validate_cli_accepts_good_v1_1_fixture() {
+    let output = Command::new(validate_bin())
+        .arg(manifest_path("tests/fixtures/cdi-v1.1-good.yaml"))
+        .output()
+        .expect("run validate binary");
+
+    assert!(
+        output.status.success(),
+        "validate failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn validate_cli_accepts_good_fixture_with_explicit_cdi_schema() {
+    let output = Command::new(validate_bin())
+        .arg("--schema")
+        .arg(manifest_path("src/schema/schema.json"))
+        .arg(manifest_path("tests/fixtures/cdi-v1.1-good.yaml"))
+        .output()
+        .expect("run validate binary");
+
+    assert!(
+        output.status.success(),
+        "validate failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn validate_cli_accepts_v1_0_legacy_intel_rdt_fields() {
+    let output = Command::new(validate_bin())
+        .arg(manifest_path(
+            "tests/fixtures/cdi-v1.0-legacy-intel-rdt.yaml",
+        ))
+        .output()
+        .expect("run validate binary");
+
+    assert!(
+        output.status.success(),
+        "validate failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn validate_cli_rejects_empty_devices_fixture() {
+    let output = Command::new(validate_bin())
+        .arg(manifest_path("tests/fixtures/cdi-empty-devices.yaml"))
+        .output()
+        .expect("run validate binary");
+
+    assert!(
+        !output.status.success(),
+        "validate unexpectedly succeeded\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn validate_cli_rejects_invalid_annotations() {
+    let output = Command::new(validate_bin())
+        .arg(manifest_path("tests/fixtures/cdi-invalid-annotation.yaml"))
+        .output()
+        .expect("run validate binary");
+
+    assert!(
+        !output.status.success(),
+        "validate unexpectedly succeeded\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn validate_cli_rejects_unknown_fields() {
+    let output = Command::new(validate_bin())
+        .arg(manifest_path("tests/fixtures/cdi-unknown-field.yaml"))
+        .output()
+        .expect("run validate binary");
+
+    assert!(
+        !output.status.success(),
+        "validate unexpectedly succeeded\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn validate_cli_rejects_v1_1_legacy_intel_rdt_fields() {
+    let output = Command::new(validate_bin())
+        .arg(manifest_path(
+            "tests/fixtures/cdi-v1.1-legacy-intel-rdt.yaml",
+        ))
+        .output()
+        .expect("run validate binary");
+
+    assert!(
+        !output.status.success(),
+        "validate unexpectedly succeeded\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn validate_cli_rejects_v1_0_enable_monitoring_field() {
+    let output = Command::new(validate_bin())
+        .arg(manifest_path(
+            "tests/fixtures/cdi-v1.0-enable-monitoring.yaml",
+        ))
+        .output()
+        .expect("run validate binary");
+
+    assert!(
+        !output.status.success(),
+        "validate unexpectedly succeeded\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn validate_cli_schema_none_skips_validation() {
+    let output = Command::new(validate_bin())
+        .arg("--schema")
+        .arg("none")
+        .arg(manifest_path("tests/fixtures/cdi-empty-devices.yaml"))
+        .output()
+        .expect("run validate binary");
+
+    assert!(
+        output.status.success(),
+        "validate failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn validate_cli_rejects_cdi_schema_without_defs_json() {
+    let tempdir = tempfile::tempdir().expect("create tempdir");
+    let schema_path = tempdir.path().join("schema.json");
+    std::fs::copy(manifest_path("src/schema/schema.json"), &schema_path)
+        .expect("copy schema without defs");
+
+    let output = Command::new(validate_bin())
+        .arg("--schema")
+        .arg(&schema_path)
+        .arg(manifest_path("tests/fixtures/cdi-v1.1-good.yaml"))
+        .output()
+        .expect("run validate binary");
+
+    assert!(
+        !output.status.success(),
+        "validate unexpectedly succeeded\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("defs.json"),
+        "stderr did not mention defs.json\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/tests/validate_cli.rs
+++ b/tests/validate_cli.rs
@@ -1,3 +1,6 @@
+// Spawns the validate binary; miri cannot emulate process creation.
+#![cfg(not(miri))]
+
 use std::{
     path::{Path, PathBuf},
     process::Command,


### PR DESCRIPTION
Currently this crate rejects any schema after 0.7.0, which takes it out of parity with the reference implementation.