### PR TITLE
deps: Bump oci-spec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -931,9 +931,9 @@ dependencies = [
 
 [[package]]
 name = "oci-spec"
-version = "0.8.4"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc3da52b83ce3258fbf29f66ac784b279453c2ac3c22c5805371b921ede0d308"
+checksum = "3df6f876ad774d6a676f7e968f5c3edacc32f90e65fe680a8b686235396556fb"
 dependencies = [
  "const_format",
  "derive_builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ path = "src/bin/validate.rs" # Path to the source file
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-oci-spec = { version = "0.8.1", features = ["runtime"] }
+oci-spec = { version = "0.10.0", features = ["runtime"] }
 anyhow = "1.0"
 clap = { version = "4.5.4", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
oci-spec 0.8 is over a year old, so try and bump to the newer version, so that kata containers is stuck managing multiple crate versions