### PR TITLE
ci: pre-approve dependabot for E2E, run E2E on workflow changes

### DIFF
--- a/.github/workflows/ci-on-push.yaml
+++ b/.github/workflows/ci-on-push.yaml
@@ -55,6 +55,10 @@ jobs:
               - '**/*.lock'
               - 'Cargo.lock'
               - '.cargo/**'
+              # Action/workflow bumps must run the E2E too - a broken or
+              # malicious action update would otherwise merge untested.
+              - '.github/workflows/**'
+              - '.github/actions/**'
 
   ci:
     needs: changes

--- a/.github/workflows/dependabot-ok-to-test.yaml
+++ b/.github/workflows/dependabot-ok-to-test.yaml
@@ -1,0 +1,37 @@
+name: Auto ok-to-test for Dependabot
+
+# Dependabot branches live in this repo and are authored only by GitHub's
+# dependabot service, so its updates are pre-approved for the E2E runner -
+# testing dependency and action bumps on real hardware is what the label
+# exists for. Safe despite the dangerous trigger: no PR code is executed,
+# the job only adds a label via the API.
+on:
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
+    types:
+      - opened
+      - reopened
+      # Dependabot rebases its PRs; re-add after each push
+      # (revoke-ok-to-test skips dependabot).
+      - synchronize
+
+permissions:
+  pull-requests: write
+  issues: write # labels ride the Issues API even on PRs
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    # PR author, not github.actor: the actor is whoever triggered the event
+    # and is spoofable (e.g. "@dependabot rebase" on a third-party PR).
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              labels: ['ok-to-test'],
+            });
+            core.info('Added ok-to-test: dependabot updates are pre-approved for E2E.');

--- a/.github/workflows/revoke-ok-to-test.yaml
+++ b/.github/workflows/revoke-ok-to-test.yaml
@@ -17,6 +17,7 @@ on:
 
 permissions:
   pull-requests: write
+  issues: write # labels ride the Issues API even on PRs
 
 concurrency:
   group: revoke-ok-to-test-${{ github.event.pull_request.number }}
@@ -25,7 +26,11 @@ concurrency:
 jobs:
   revoke:
     runs-on: ubuntu-latest
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
+    # Dependabot-authored PRs are exempt: they are pre-approved
+    # (dependabot-ok-to-test.yaml) and dependabot rebases on every update -
+    # revoking here would race the auto-labeler on the same event. Author
+    # check, not github.actor: the actor is spoofable.
+    if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
     steps:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:


### PR DESCRIPTION
Two gaps in the E2E gating from #80:

1. **Dependabot never gets tested on the runner.** Its branches live in this repo and are authored only by GitHub's service, so they are pre-approved: a `pull_request_target` workflow adds `ok-to-test` automatically (PR-author check — `github.actor` is spoofable via `@dependabot rebase` on third-party PRs, flagged by zizmor's bot-conditions audit), and `revoke-ok-to-test` exempts dependabot-authored PRs since dependabot rebases on every update and the revoke would race the auto-labeler.

2. **Action/workflow bumps skip the E2E.** The paths filter only watched Rust/toml/lock files, so a pinned-action update would merge with `CI Complete` green while the E2E never ran. `.github/workflows/**` and `.github/actions/**` are now part of the `code` filter — this PR itself exercises that path.
