### PR TITLE
ci: /kata-checkout slash command to switch the runner's kata tree

### DIFF
--- a/.github/workflows/kata-checkout.yaml
+++ b/.github/workflows/kata-checkout.yaml
@@ -1,0 +1,118 @@
+name: kata-checkout slash command
+
+# "/kata-checkout <ref> [owner/repo]" on a PR switches the runner's kata
+# source tree to an arbitrary ref. WHY: ecosystem-coupled changes (e.g. an
+# oci-spec bump) can only go green against a kata WIP branch that carries
+# the matching change - this lets the pair be E2E-validated on the metal
+# before either repo merges. Runs the default-branch definition; no PR code
+# executes here.
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+
+# The kata tree is shared runner state; queued switches must not interleave.
+concurrency:
+  group: kata-checkout-tree
+  cancel-in-progress: false
+
+env:
+  KATA_SRC_DIR: /home/container-device-interface-rs/actions-runner/_work/kata-containers
+
+jobs:
+  checkout:
+    # Write-access users only (the same set that can grant ok-to-test) -
+    # this puts arbitrary kata code on the self-hosted runner. Association
+    # is set by GitHub, not spoofable from the comment. Trailing space:
+    # the command requires an argument and must not prefix-match others.
+    if: >-
+      ${{ github.event.issue.pull_request &&
+          startsWith(github.event.comment.body, '/kata-checkout ') &&
+          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) }}
+    runs-on: g5g.metal
+    permissions:
+      contents: read
+      pull-requests: write # acknowledge with the resolved SHA
+      issues: write # comments on PRs ride the Issues API
+
+    steps:
+      - name: Parse command
+        id: cmd
+        env:
+          BODY: ${{ github.event.comment.body }}
+        run: |
+          set -euo pipefail
+
+          # Strict charsets keep the comment body out of shell/git option
+          # positions.
+          read -r _ ref repo <<<"${BODY}" || true
+          repo="${repo:-kata-containers/kata-containers}"
+          # "-" is git's previous-checkout notation; anything else must
+          # start alphanumeric so a ref can never look like an option.
+          if [[ "${ref:-}" != "-" ]] && [[ ! "${ref:-}" =~ ^[A-Za-z0-9][A-Za-z0-9._/-]*$ ]]; then
+            echo "ERROR: usage: /kata-checkout <ref> [owner/repo]" >&2
+            exit 1
+          fi
+          if [[ ! "${repo}" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]]; then
+            echo "ERROR: invalid repo '${repo}'" >&2
+            exit 1
+          fi
+          echo "ref=${ref}" >> "$GITHUB_OUTPUT"
+          echo "repo=${repo}" >> "$GITHUB_OUTPUT"
+
+      - name: Switch the kata tree
+        env:
+          REF: ${{ steps.cmd.outputs.ref }}
+          REPO: ${{ steps.cmd.outputs.repo }}
+        run: |
+          set -euo pipefail
+
+          cd "${KATA_SRC_DIR}"
+
+          # Recorded so the ack comment always says how to get back.
+          prev=$(git describe --tags --always)
+          echo "prev=${prev}" >> "$GITHUB_OUTPUT"
+
+          git reset --hard
+          # No git clean: build/ (rootfs, image) is untracked and survives
+          # the switch - a full clean would force a 30+ minute reprovision
+          # (update-kata) for changes that only affect the agent.
+          if [[ "${REF}" == "-" ]]; then
+            # git's previous-checkout notation; the reflog persists on the
+            # runner, so this undoes the last switch.
+            git checkout --detach -
+          elif git fetch -- "https://github.com/${REPO}.git" "${REF}" 2>/dev/null; then
+            git checkout --detach FETCH_HEAD
+          elif git rev-parse --verify --quiet "${REF}^{commit}" >/dev/null; then
+            # Already-local tag or SHA (e.g. the provisioned release tag).
+            git checkout --detach "${REF}"
+          else
+            echo "ERROR: '${REF}' not found in ${REPO} or locally" >&2
+            exit 1
+          fi
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          git log -1 --oneline
+        id: tree
+
+      - name: Acknowledge on the PR
+        # github-script instead of gh: no dependency on CLI presence on the
+        # self-hosted runner, consistent with the other label/comment flows.
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          REF: ${{ steps.cmd.outputs.ref }}
+          REPO: ${{ steps.cmd.outputs.repo }}
+          SHA: ${{ steps.tree.outputs.sha }}
+          PREV: ${{ steps.tree.outputs.prev }}
+        with:
+          script: |
+            const { REF, REPO, SHA, PREV } = process.env;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `Runner kata tree switched to \`${REPO}#${REF}\` (\`${SHA}\`), previously at \`${PREV}\`. ` +
+                `Re-apply \`ok-to-test\` to run the E2E against it. Restore with \`/kata-checkout -\` or ` +
+                `\`/kata-checkout ${PREV}\`; full reprovision via the update-kata workflow.`,
+            });

--- a/.github/workflows/update-kata.yaml
+++ b/.github/workflows/update-kata.yaml
@@ -30,6 +30,20 @@ on:
         required: false
         type: string
         default: ""
+      # For dependency-transition windows (e.g. the oci-spec bump): rebuild
+      # rootfs/kernel from a kata WIP ref without reverting the tree to a
+      # release. Release-only steps (kata-static install, tag resolution)
+      # are skipped; the installed runtime stays as-is.
+      kata-ref:
+        description: "Arbitrary kata ref (branch/SHA). Overrides kata-tag; skips the kata-static release install."
+        required: false
+        type: string
+        default: ""
+      kata-repo:
+        description: "Repo for kata-ref (owner/name)"
+        required: false
+        type: string
+        default: "kata-containers/kata-containers"
 
 permissions:
   contents: read
@@ -91,6 +105,7 @@ jobs:
 
       - name: Resolve release tag
         id: tag
+        if: ${{ inputs.kata-ref == '' }}
         env:
           GH_TOKEN: ${{ github.token }}
           REQUESTED_TAG: ${{ inputs.kata-tag }}
@@ -122,9 +137,11 @@ jobs:
           echo "Resolved '${REQUESTED_TAG:-latest}' -> ${tag}"
           echo "tag=${tag}" >> "${GITHUB_OUTPUT}"
 
-      - name: Sync kata-containers source tree to ${{ steps.tag.outputs.tag }}
+      - name: Sync kata-containers source tree to ${{ inputs.kata-ref || steps.tag.outputs.tag }}
         env:
           TAG: ${{ steps.tag.outputs.tag }}
+          REF: ${{ inputs.kata-ref }}
+          REF_REPO: ${{ inputs.kata-repo }}
         run: |
           set -euo pipefail
 
@@ -157,8 +174,13 @@ jobs:
           # by `make rootfs-image-nvidia-gpu-tarball` below.
           git reset --hard
           git clean -ffdx
-          git fetch --tags --force --prune origin
-          git checkout --detach "refs/tags/${TAG}"
+          if [[ -n "${REF}" ]]; then
+            git fetch -- "https://github.com/${REF_REPO}.git" "${REF}"
+            git checkout --detach FETCH_HEAD
+          else
+            git fetch --tags --force --prune origin
+            git checkout --detach "refs/tags/${TAG}"
+          fi
 
           echo "kata-containers @ $(git rev-parse HEAD) ($(git describe --tags --always))"
 
@@ -214,6 +236,9 @@ jobs:
 
       - name: Download kata-static asset
         id: download
+        # Release-only: an arbitrary ref has no published kata-static asset;
+        # the installed runtime stays at its current release.
+        if: ${{ inputs.kata-ref == '' }}
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.tag.outputs.tag }}
@@ -237,6 +262,7 @@ jobs:
           echo "asset=${workdir}/${asset}" >> "${GITHUB_OUTPUT}"
 
       - name: Install kata-static to /opt/kata
+        if: ${{ inputs.kata-ref == '' }}
         env:
           TAG: ${{ steps.tag.outputs.tag }}
           ASSET: ${{ steps.download.outputs.asset }}
@@ -310,7 +336,7 @@ jobs:
 
       - name: Summary
         env:
-          TAG: ${{ steps.tag.outputs.tag }}
+          TAG: ${{ inputs.kata-ref || steps.tag.outputs.tag }}
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
`/kata-checkout <ref> [owner/repo]` on any PR switches the self-hosted runner's kata source tree to that ref (default repo: kata-containers/kata-containers) and replies with the resolved SHA.

**Why:** breaks the chicken-and-egg on ecosystem-coupled bumps (#78/#79's oci-spec 0.10): provision the runner from a kata WIP branch carrying the matching change, re-apply `ok-to-test`, and the E2E validates the future kata+CDI pair on the metal before either repo merges anything.

**Security:** `issue_comment` runs the default-branch workflow (no PR code executes here), maintainer-only via `author_association`, and strict charsets on ref/repo keep the comment body out of shell/git option positions. `build/` is preserved so a switch costs seconds; full reprovision stays with update-kata.

Note: slash commands only become active once this merges (issue_comment resolves against the default branch).
