### PR TITLE
ci: harden /kata-checkout - maintainer role, canonical repo only

### DIFF
--- a/.github/workflows/kata-checkout.yaml
+++ b/.github/workflows/kata-checkout.yaml
@@ -1,7 +1,8 @@
 name: kata-checkout slash command
 
-# "/kata-checkout <ref> [owner/repo]" on a PR switches the runner's kata
-# source tree to an arbitrary ref. WHY: ecosystem-coupled changes (e.g. an
+# "/kata-checkout <ref>" on a PR switches the runner's kata source tree to
+# a ref from the canonical kata-containers repo ONLY - fork code never
+# reaches the runner. WHY: ecosystem-coupled changes (e.g. an
 # oci-spec bump) can only go green against a kata WIP branch that carries
 # the matching change - this lets the pair be E2E-validated on the metal
 # before either repo merges. Runs the default-branch definition; no PR code
@@ -20,13 +21,15 @@ concurrency:
 
 env:
   KATA_SRC_DIR: /home/container-device-interface-rs/actions-runner/_work/kata-containers
+  # Canonical repo only - never forks.
+  KATA_REPO: kata-containers/kata-containers
 
 jobs:
   checkout:
-    # Write-access users only (the same set that can grant ok-to-test) -
-    # this puts arbitrary kata code on the self-hosted runner. Association
-    # is set by GitHub, not spoofable from the comment. Trailing space:
-    # the command requires an argument and must not prefix-match others.
+    # Cheap pre-filter; the real gate is the maintainer check below.
+    # Association is set by GitHub, not spoofable from the comment.
+    # Trailing space: the command requires an argument and must not
+    # prefix-match other commands.
     if: >-
       ${{ github.event.issue.pull_request &&
           startsWith(github.event.comment.body, '/kata-checkout ') &&
@@ -38,6 +41,40 @@ jobs:
       issues: write # comments on PRs ride the Issues API
 
     steps:
+      # Association alone is too coarse (MEMBER = any org member): this puts
+      # arbitrary kata code on the self-hosted runner, so require an actual
+      # repository role of admin or maintain, resolved from the API - the
+      # commenter cannot influence it. Runs before anything touches the tree.
+      - name: Require maintainer permission
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const user = context.payload.comment.user.login;
+            let role = 'none';
+            try {
+              const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: user,
+              });
+              role = data.role_name || data.permission;
+            } catch (error) {
+              // 404 = not a collaborator: fall through to the denial path.
+              // Anything else fails closed without a comment - deliberate.
+              if (error.status !== 404) throw error;
+            }
+            if (!['admin', 'maintain'].includes(role)) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: `\`/kata-checkout\` requires maintainer permission on this repository; @${user} has role \`${role}\`.`,
+              });
+              core.setFailed(`denied: ${user} has role '${role}', need admin or maintain`);
+              return; // setFailed does not stop execution
+            }
+            core.info(`${user} authorized with role '${role}'`);
+
       - name: Parse command
         id: cmd
         env:
@@ -45,27 +82,25 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Strict charsets keep the comment body out of shell/git option
-          # positions.
-          read -r _ ref repo <<<"${BODY}" || true
-          repo="${repo:-kata-containers/kata-containers}"
+          # Strict charset keeps the comment body out of shell/git option
+          # positions; a single argument only - no repo override, forks are
+          # deliberately not supported.
+          read -r _ ref extra <<<"${BODY}" || true
+          if [[ -n "${extra:-}" ]]; then
+            echo "ERROR: usage: /kata-checkout <ref> (canonical kata-containers repo only)" >&2
+            exit 1
+          fi
           # "-" is git's previous-checkout notation; anything else must
           # start alphanumeric so a ref can never look like an option.
           if [[ "${ref:-}" != "-" ]] && [[ ! "${ref:-}" =~ ^[A-Za-z0-9][A-Za-z0-9._/-]*$ ]]; then
-            echo "ERROR: usage: /kata-checkout <ref> [owner/repo]" >&2
-            exit 1
-          fi
-          if [[ ! "${repo}" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]]; then
-            echo "ERROR: invalid repo '${repo}'" >&2
+            echo "ERROR: usage: /kata-checkout <ref>" >&2
             exit 1
           fi
           echo "ref=${ref}" >> "$GITHUB_OUTPUT"
-          echo "repo=${repo}" >> "$GITHUB_OUTPUT"
 
       - name: Switch the kata tree
         env:
           REF: ${{ steps.cmd.outputs.ref }}
-          REPO: ${{ steps.cmd.outputs.repo }}
         run: |
           set -euo pipefail
 
@@ -83,13 +118,13 @@ jobs:
             # git's previous-checkout notation; the reflog persists on the
             # runner, so this undoes the last switch.
             git checkout --detach -
-          elif git fetch -- "https://github.com/${REPO}.git" "${REF}" 2>/dev/null; then
+          elif git fetch -- "https://github.com/${KATA_REPO}.git" "${REF}" 2>/dev/null; then
             git checkout --detach FETCH_HEAD
           elif git rev-parse --verify --quiet "${REF}^{commit}" >/dev/null; then
             # Already-local tag or SHA (e.g. the provisioned release tag).
             git checkout --detach "${REF}"
           else
-            echo "ERROR: '${REF}' not found in ${REPO} or locally" >&2
+            echo "ERROR: '${REF}' not found in ${KATA_REPO} or locally" >&2
             exit 1
           fi
           echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
@@ -102,17 +137,16 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           REF: ${{ steps.cmd.outputs.ref }}
-          REPO: ${{ steps.cmd.outputs.repo }}
           SHA: ${{ steps.tree.outputs.sha }}
           PREV: ${{ steps.tree.outputs.prev }}
         with:
           script: |
-            const { REF, REPO, SHA, PREV } = process.env;
+            const { REF, SHA, PREV } = process.env;
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: `Runner kata tree switched to \`${REPO}#${REF}\` (\`${SHA}\`), previously at \`${PREV}\`. ` +
+              body: `Runner kata tree switched to \`kata-containers/kata-containers#${REF}\` (\`${SHA}\`), previously at \`${PREV}\`. ` +
                 `Re-apply \`ok-to-test\` to run the E2E against it. Restore with \`/kata-checkout -\` or ` +
                 `\`/kata-checkout ${PREV}\`; full reprovision via the update-kata workflow.`,
             });

--- a/.github/workflows/update-kata.yaml
+++ b/.github/workflows/update-kata.yaml
@@ -35,15 +35,10 @@ on:
       # release. Release-only steps (kata-static install, tag resolution)
       # are skipped; the installed runtime stays as-is.
       kata-ref:
-        description: "Arbitrary kata ref (branch/SHA). Overrides kata-tag; skips the kata-static release install."
+        description: "Arbitrary kata ref (branch/SHA) from the canonical kata repo. Overrides kata-tag; skips the kata-static release install."
         required: false
         type: string
         default: ""
-      kata-repo:
-        description: "Repo for kata-ref (owner/name)"
-        required: false
-        type: string
-        default: "kata-containers/kata-containers"
 
 permissions:
   contents: read
@@ -141,7 +136,6 @@ jobs:
         env:
           TAG: ${{ steps.tag.outputs.tag }}
           REF: ${{ inputs.kata-ref }}
-          REF_REPO: ${{ inputs.kata-repo }}
         run: |
           set -euo pipefail
 
@@ -175,7 +169,8 @@ jobs:
           git reset --hard
           git clean -ffdx
           if [[ -n "${REF}" ]]; then
-            git fetch -- "https://github.com/${REF_REPO}.git" "${REF}"
+            # Canonical repo only - fork code never reaches the runner.
+            git fetch -- "https://github.com/${KATA_REPO}.git" "${REF}"
             git checkout --detach FETCH_HEAD
           else
             git fetch --tags --force --prune origin


### PR DESCRIPTION
Follow-up hardening that #91 was missing when it merged:

1. **Maintainer role required.** `author_association` only proves org membership; the first step now resolves the commenter's actual repository role via `getCollaboratorPermissionLevel` (uninfluenceable from the comment) and denies anything below `admin`/`maintain` with an explanatory reply. Fails closed.
2. **Canonical repo only.** `/kata-checkout <ref>` takes exactly one argument - the `[owner/repo]` override and update-kata's `kata-repo` input are gone; the fetch URL is built from a hardcoded `kata-containers/kata-containers`. Fork code never reaches the self-hosted runner, and WIP branches must live in the canonical repo under org protections.
