### PR TITLE
test: raise line coverage to 98%, gate at 95% total and per file

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -82,8 +82,7 @@ jobs:
       # threshold fails. `report` rescores the profdata recorded by the
       # generate step; sudo because that data is root-owned. The per-file
       # bound stops an aggregate score from masking under-tested modules.
-      # api.rs is exempt: its device-listing printer needs a populated
-      # /etc/cdi, which CI runners do not have. Ratchet both bounds up as
-      # coverage improves (baseline ~90% total, worst file ~72%).
-      - name: Enforce minimum 85% total and 70% per-file line coverage
-        run: sudo -E env "PATH=$PATH" cargo llvm-cov report --fail-under-lines 85 --fail-under-file-lines 70 --ignore-filename-regex 'bin/cdi_ops/api\.rs$'
+      # Ratchet both bounds up as coverage improves (baseline ~96% total,
+      # worst file ~86%).
+      - name: Enforce minimum 92% total and 80% per-file line coverage
+        run: sudo -E env "PATH=$PATH" cargo llvm-cov report --fail-under-lines 92 --fail-under-file-lines 80

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -66,8 +66,10 @@ jobs:
         with:
           tool: cargo-llvm-cov@0.8.7
 
+      # Run as root: the mknod device tests self-skip as non-root and their
+      # skipped bodies would count against container_edits_unix.
       - name: Generate coverage
-        run: cargo llvm-cov --locked --all-features --workspace --lcov --output-path lcov.info
+        run: sudo -E env "PATH=$PATH" cargo llvm-cov --locked --all-features --workspace --lcov --output-path lcov.info
 
       - name: Upload coverage to Coveralls
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
@@ -77,7 +79,11 @@ jobs:
           format: lcov
 
       # Gate after the upload so Coveralls still receives the report when the
-      # threshold fails. Current baseline is ~34% line coverage; the floor
-      # prevents regressions. Ratchet this up as coverage improves.
-      - name: Enforce minimum 30% line coverage
-        run: cargo llvm-cov report --fail-under-lines 30
+      # threshold fails. `report` rescores the profdata recorded by the
+      # generate step; sudo because that data is root-owned. The per-file
+      # bound stops an aggregate score from masking under-tested modules.
+      # api.rs is exempt: its device-listing printer needs a populated
+      # /etc/cdi, which CI runners do not have. Ratchet both bounds up as
+      # coverage improves (baseline ~90% total, worst file ~72%).
+      - name: Enforce minimum 85% total and 70% per-file line coverage
+        run: sudo -E env "PATH=$PATH" cargo llvm-cov report --fail-under-lines 85 --fail-under-file-lines 70 --ignore-filename-regex 'bin/cdi_ops/api\.rs$'

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -66,10 +66,14 @@ jobs:
         with:
           tool: cargo-llvm-cov@0.8.7
 
-      # Run as root: the mknod device tests self-skip as non-root and their
-      # skipped bodies would count against container_edits_unix.
+      # Two passes merged into one profile: the root pass executes the mknod
+      # device tests, the non-root pass executes their skip branches -
+      # either alone leaves the other side uncovered.
       - name: Generate coverage
-        run: sudo -E env "PATH=$PATH" cargo llvm-cov --locked --all-features --workspace --lcov --output-path lcov.info
+        run: |
+          cargo llvm-cov --locked --all-features --workspace --no-report
+          sudo -E env "PATH=$PATH" cargo llvm-cov --locked --all-features --workspace --no-report
+          sudo -E env "PATH=$PATH" cargo llvm-cov report --lcov --output-path lcov.info
 
       - name: Upload coverage to Coveralls
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
@@ -80,9 +84,8 @@ jobs:
 
       # Gate after the upload so Coveralls still receives the report when the
       # threshold fails. `report` rescores the profdata recorded by the
-      # generate step; sudo because that data is root-owned. The per-file
-      # bound stops an aggregate score from masking under-tested modules.
-      # Ratchet both bounds up as coverage improves (baseline ~96% total,
-      # worst file ~86%).
-      - name: Enforce minimum 92% total and 80% per-file line coverage
-        run: sudo -E env "PATH=$PATH" cargo llvm-cov report --fail-under-lines 92 --fail-under-file-lines 80
+      # generate steps; sudo because that data is root-owned. The per-file
+      # bound stops an aggregate score from masking under-tested modules
+      # (baseline ~98% total, worst file ~95.5%).
+      - name: Enforce minimum 95% total and per-file line coverage
+        run: sudo -E env "PATH=$PATH" cargo llvm-cov report --fail-under-lines 95 --fail-under-file-lines 95

--- a/src/annotations.rs
+++ b/src/annotations.rs
@@ -139,7 +139,7 @@ mod tests {
     use std::collections::HashMap;
 
     use crate::annotations::{
-        annotation_key, annotation_value, parse_annotations, ANNOTATION_PREFIX,
+        annotation_key, annotation_value, parse_annotations, update_annotations, ANNOTATION_PREFIX,
     };
 
     #[test]
@@ -269,5 +269,45 @@ mod tests {
             let device_id = &case.device_id;
             assert!(annotation_key(plugin_name, device_id).is_err());
         }
+    }
+
+    #[test]
+    fn update_annotations_inserts_and_detects_collisions() {
+        let annotations = update_annotations(
+            None,
+            "vendor.device-type",
+            "gpu0",
+            vec!["vendor.com/class=dev0".to_string()],
+        )
+        .unwrap();
+        assert_eq!(annotations.len(), 1);
+        let value = annotations.values().next().unwrap();
+        assert_eq!(value, "vendor.com/class=dev0");
+
+        let err = update_annotations(
+            Some(annotations),
+            "vendor.device-type",
+            "gpu0",
+            vec!["vendor.com/class=dev1".to_string()],
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("collision"));
+    }
+
+    #[test]
+    fn annotation_key_rejects_empty_parts() {
+        assert!(annotation_key("", "id").is_err());
+        assert!(annotation_key("plugin", "").is_err());
+    }
+
+    #[test]
+    fn parse_annotations_rejects_unqualified_devices() {
+        let mut annotations = HashMap::new();
+        annotations.insert(
+            format!("{}vendor.device-type_gpu0", ANNOTATION_PREFIX),
+            "not-a-qualified-name".to_string(),
+        );
+        let err = parse_annotations(&annotations).unwrap_err();
+        assert!(err.to_string().contains("invalid CDI device name"));
     }
 }

--- a/src/bin/cdi_ops/api.rs
+++ b/src/bin/cdi_ops/api.rs
@@ -71,3 +71,62 @@ fn cdi_print_device(idx: usize, dev: Device, verbose: bool, format: &str, level:
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cdi::cache::with_auto_refresh;
+    use cdi::default_cache::{configure, refresh};
+    use cdi::spec_dirs::with_spec_dirs;
+    use std::fs;
+
+    // One test: the default cache is a process-wide singleton shared by
+    // every test in this binary.
+    #[test]
+    fn list_and_inject_through_the_default_cache() {
+        // Before any spec dir is configured the list is empty: early return.
+        cdi_list_devices(false, " ").unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("vendor.yaml"),
+            r#"cdiVersion: "0.6.0"
+kind: "vendor.com/device"
+containerEdits:
+  env:
+    - "GLOBAL=1"
+devices:
+  - name: "gpu0"
+    containerEdits:
+      env:
+        - "VENDOR=1"
+"#,
+        )
+        .unwrap();
+        configure(vec![
+            with_spec_dirs(&[dir.path().to_str().unwrap()]),
+            with_auto_refresh(false),
+        ])
+        .unwrap();
+        refresh().unwrap();
+
+        // Non-verbose and verbose (the latter prints the global spec edits).
+        cdi_list_devices(false, " ").unwrap();
+        cdi_list_devices(true, "json").unwrap();
+        cdi_list_devices(true, "").unwrap();
+
+        let mut oci_spec = oci::Spec::default();
+        cdi_inject_devices(
+            &mut oci_spec,
+            vec![
+                "vendor.com/device=gpu0".to_string(),
+                "vendor.com/device=unknown".to_string(), // filtered, not an error
+            ],
+            "yaml",
+        )
+        .unwrap();
+        let env = oci_spec.process().as_ref().unwrap().env().as_ref().unwrap();
+        assert!(env.contains(&"VENDOR=1".to_string()));
+        assert!(env.contains(&"GLOBAL=1".to_string()));
+    }
+}

--- a/src/bin/cdi_ops/api.rs
+++ b/src/bin/cdi_ops/api.rs
@@ -84,7 +84,14 @@ mod tests {
     // every test in this binary.
     #[test]
     fn list_and_inject_through_the_default_cache() {
-        // Before any spec dir is configured the list is empty: early return.
+        // Empty spec dir first: the "No CDI devices found" early return.
+        let empty = tempfile::tempdir().unwrap();
+        configure(vec![
+            with_spec_dirs(&[empty.path().to_str().unwrap()]),
+            with_auto_refresh(false),
+        ])
+        .unwrap();
+        refresh().unwrap();
         cdi_list_devices(false, " ").unwrap();
 
         let dir = tempfile::tempdir().unwrap();
@@ -128,5 +135,28 @@ devices:
         let env = oci_spec.process().as_ref().unwrap().env().as_ref().unwrap();
         assert!(env.contains(&"VENDOR=1".to_string()));
         assert!(env.contains(&"GLOBAL=1".to_string()));
+
+        // A loadable spec whose device node cannot be stat'ed fails at
+        // inject time (fill_missing_info) - the error-print path.
+        fs::write(
+            dir.path().join("broken.yaml"),
+            r#"cdiVersion: "0.6.0"
+kind: "vendor2.com/device"
+devices:
+  - name: "bad0"
+    containerEdits:
+      deviceNodes:
+        - path: "/nonexistent/device/node"
+"#,
+        )
+        .unwrap();
+        refresh().unwrap();
+        let mut oci_spec = oci::Spec::default();
+        cdi_inject_devices(
+            &mut oci_spec,
+            vec!["vendor2.com/device=bad0".to_string()],
+            "yaml",
+        )
+        .unwrap();
     }
 }

--- a/src/bin/cdi_ops/format.rs
+++ b/src/bin/cdi_ops/format.rs
@@ -177,4 +177,30 @@ index: 35
 "#;
         assert_eq!(result.trim(), expected.trim());
     }
+
+    #[test]
+    fn choose_format_prefers_explicit_then_extension() {
+        assert_eq!(choose_format("json", "/x.yaml"), "json");
+        assert_eq!(choose_format("", "/x.json"), "json");
+        assert_eq!(choose_format("", "/x.yaml"), "yaml");
+        assert_eq!(choose_format("", "/x.txt"), "");
+        assert_eq!(choose_format("", "no-extension"), "");
+    }
+
+    #[test]
+    fn marshal_indents_every_line_in_both_formats() {
+        #[derive(serde::Serialize)]
+        struct Obj {
+            a: u32,
+            b: String,
+        }
+        let obj = Obj {
+            a: 1,
+            b: "x".to_string(),
+        };
+        for format in ["json", "yaml"] {
+            let out = marshal_object(2, &obj, format);
+            assert!(out.lines().all(|l| l.starts_with("  ")), "{format}: {out}");
+        }
+    }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -298,6 +298,7 @@ impl Cache {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::spec_dirs::with_spec_dirs;
     use crate::{
         spec::new_spec,
         specs::config::{
@@ -306,7 +307,124 @@ mod tests {
         },
     };
     use oci_spec::runtime::Spec as OCISpec;
-    use std::{collections::HashMap, path::PathBuf};
+    use std::{collections::HashMap, fs, path::PathBuf};
+
+    fn spec_yaml(kind: &str, env: &str) -> String {
+        format!(
+            r#"cdiVersion: "0.6.0"
+kind: "{kind}"
+devices:
+  - name: "gpu0"
+    containerEdits:
+      env:
+        - "{env}"
+"#
+        )
+    }
+
+    fn dir_cache(dirs: &[&str]) -> Cache {
+        let mut cache = Cache::default();
+        with_spec_dirs(dirs)(&mut cache);
+        cache
+    }
+
+    #[test]
+    fn refresh_scans_dirs_and_answers_queries() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("vendor.yaml"),
+            spec_yaml("vendor.com/device", "VENDOR=1"),
+        )
+        .unwrap();
+        let mut cache = dir_cache(&[dir.path().to_str().unwrap()]);
+
+        cache.refresh().unwrap();
+
+        assert_eq!(cache.list_devices(), vec!["vendor.com/device=gpu0"]);
+        assert_eq!(cache.list_vendors(), vec!["vendor.com"]);
+        assert_eq!(cache.get_vendor_specs("vendor.com").len(), 1);
+        assert!(cache.get_vendor_specs("other.com").is_empty());
+        assert!(cache.get_device("vendor.com/device=gpu0").is_some());
+        assert!(cache.get_device("vendor.com/device=missing").is_none());
+    }
+
+    #[test]
+    fn auto_refresh_picks_up_new_specs_without_manual_refresh() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut cache = dir_cache(&[dir.path().to_str().unwrap()]);
+        with_auto_refresh(true)(&mut cache);
+        assert!(cache.list_devices().is_empty());
+
+        fs::write(
+            dir.path().join("vendor.yaml"),
+            spec_yaml("vendor.com/device", "VENDOR=1"),
+        )
+        .unwrap();
+
+        // No explicit refresh(): the query must trigger it.
+        assert_eq!(cache.list_devices(), vec!["vendor.com/device=gpu0"]);
+    }
+
+    #[test]
+    fn later_dir_wins_on_conflicting_device_names() {
+        let low = tempfile::tempdir().unwrap();
+        let high = tempfile::tempdir().unwrap();
+        fs::write(
+            low.path().join("a.yaml"),
+            spec_yaml("vendor.com/device", "FROM=low"),
+        )
+        .unwrap();
+        fs::write(
+            high.path().join("b.yaml"),
+            spec_yaml("vendor.com/device", "FROM=high"),
+        )
+        .unwrap();
+        let mut cache = dir_cache(&[low.path().to_str().unwrap(), high.path().to_str().unwrap()]);
+
+        cache.refresh().unwrap();
+
+        let dev = cache.get_device("vendor.com/device=gpu0").unwrap();
+        assert_eq!(dev.get_spec().get_priority(), 1);
+    }
+
+    #[test]
+    fn same_priority_conflicts_are_reported() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("a.yaml"),
+            spec_yaml("vendor.com/device", "FROM=a"),
+        )
+        .unwrap();
+        fs::write(
+            dir.path().join("b.yaml"),
+            spec_yaml("vendor.com/device", "FROM=b"),
+        )
+        .unwrap();
+        let mut cache = dir_cache(&[dir.path().to_str().unwrap()]);
+
+        let err = cache.refresh().unwrap_err();
+
+        assert!(err.to_string().contains("conflicting device"));
+        assert!(!cache.errors.is_empty());
+    }
+
+    #[test]
+    fn inject_devices_requires_an_oci_spec() {
+        let mut cache = Cache::default();
+        let err = cache.inject_devices(None, vec![]).unwrap_err();
+        assert!(err.to_string().contains("OCI Spec is empty"));
+    }
+
+    #[test]
+    fn inject_devices_reports_unresolvable_devices() {
+        let mut cache = Cache::default();
+        let mut oci_spec = OCISpec::default();
+        let err = cache
+            .inject_devices(Some(&mut oci_spec), vec!["vendor.com/device=nope".into()])
+            .unwrap_err();
+        assert!(err.to_string().contains("unresolvable CDI devices"));
+        assert!(err.to_string().contains("vendor.com/device=nope"));
+    }
 
     #[test]
     fn inject_devices_preserves_spec_level_intel_rdt_with_device_edits() {

--- a/src/container_edits.rs
+++ b/src/container_edits.rs
@@ -615,4 +615,265 @@ mod tests {
         assert_eq!(Some(1234), dev.uid());
         assert_eq!(Some(5678), dev.gid());
     }
+
+    fn named_device_node(path: &str, perms: Option<&str>) -> CDIDeviceNode {
+        CDIDeviceNode {
+            path: path.to_string(),
+            r#type: Some("c".to_string()),
+            major: Some(1),
+            minor: Some(3),
+            permissions: perms.map(str::to_string),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn apply_inherits_process_uid_gid_and_maps_permissions() {
+        let mut edits = ContainerEdits::new();
+        edits.container_edits.env = Some(vec![]); // empty env list: no-op branch
+        edits.container_edits.device_nodes = Some(vec![
+            named_device_node("/dev/a", None),         // -> rwm
+            named_device_node("/dev/b", Some("none")), // -> ""
+            named_device_node("/dev/c", Some("rw")),   // -> rw
+        ]);
+
+        let mut spec = oci::Spec::default();
+        if let Some(process) = spec.process_mut() {
+            process.user_mut().set_uid(1000);
+            process.user_mut().set_gid(2000);
+        }
+        edits.apply(&mut spec).unwrap();
+
+        let linux = spec.linux().as_ref().unwrap();
+        let dev = &linux.devices().as_ref().unwrap()[0];
+        assert_eq!((Some(1000), Some(2000)), (dev.uid(), dev.gid()));
+
+        let access: Vec<_> = linux
+            .resources()
+            .as_ref()
+            .unwrap()
+            .devices()
+            .as_ref()
+            .unwrap()
+            .iter()
+            .map(|d| d.access().clone().unwrap_or_default())
+            .collect();
+        assert_eq!(access, vec!["rwm", "", "rw"]);
+    }
+
+    #[test]
+    fn apply_places_every_hook_kind() {
+        let kinds = [
+            "prestart",
+            "createRuntime",
+            "createContainer",
+            "startContainer",
+            "poststart",
+            "poststop",
+        ];
+        let mut edits = ContainerEdits::new();
+        edits.container_edits.hooks = Some(
+            kinds
+                .iter()
+                .map(|k| CDIHook {
+                    hook_name: k.to_string(),
+                    path: "/bin/true".to_string(),
+                    ..Default::default()
+                })
+                .collect(),
+        );
+
+        let mut spec = oci::Spec::default();
+        edits.apply(&mut spec).unwrap();
+
+        let hooks = spec.hooks().as_ref().unwrap();
+        assert_eq!(hooks.prestart().as_ref().unwrap().len(), 1);
+        assert_eq!(hooks.create_runtime().as_ref().unwrap().len(), 1);
+        assert_eq!(hooks.create_container().as_ref().unwrap().len(), 1);
+        assert_eq!(hooks.start_container().as_ref().unwrap().len(), 1);
+        assert_eq!(hooks.poststart().as_ref().unwrap().len(), 1);
+        assert_eq!(hooks.poststop().as_ref().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn apply_rejects_unknown_hook_names() {
+        let mut edits = ContainerEdits::new();
+        edits.container_edits.hooks = Some(vec![CDIHook {
+            hook_name: "bogus".to_string(),
+            path: "/bin/true".to_string(),
+            ..Default::default()
+        }]);
+        let err = edits.apply(&mut oci::Spec::default()).unwrap_err();
+        assert!(err.to_string().contains("no such hook"));
+    }
+
+    #[test]
+    fn append_merges_intel_rdt_from_other() {
+        let mut base = ContainerEdits::new();
+        base.container_edits.env = Some(vec!["A=1".to_string()]);
+        let mut other = ContainerEdits::new();
+        other.container_edits.intel_rdt = Some(CDIIntelRdt {
+            clos_id: Some("class".to_string()),
+            ..Default::default()
+        });
+        other.container_edits.env = Some(vec!["B=2".to_string()]);
+
+        base.append(other).unwrap();
+
+        assert_eq!(
+            base.container_edits.intel_rdt.as_ref().unwrap().clos_id,
+            Some("class".to_string())
+        );
+        assert_eq!(
+            base.container_edits.env,
+            Some(vec!["A=1".to_string(), "B=2".to_string()])
+        );
+    }
+
+    #[test]
+    fn validate_rejects_each_invalid_component() {
+        let case = |mutate: &dyn Fn(&mut CDIContainerEdits), needle: &str| {
+            let mut edits = ContainerEdits::new();
+            mutate(&mut edits.container_edits);
+            let err = edits.validate().unwrap_err();
+            assert!(
+                format!("{err:?}").contains(needle),
+                "expected {needle:?} in {err:?}"
+            );
+        };
+
+        case(
+            &|e| e.env = Some(vec!["NOEQUALS".into()]),
+            "invalid environment variable",
+        );
+        case(
+            &|e| {
+                e.device_nodes = Some(vec![CDIDeviceNode {
+                    path: String::new(),
+                    ..Default::default()
+                }])
+            },
+            "invalid (empty) device path",
+        );
+        case(
+            &|e| {
+                e.device_nodes = Some(vec![CDIDeviceNode {
+                    path: "/dev/x".into(),
+                    permissions: Some("rwx".into()),
+                    ..Default::default()
+                }])
+            },
+            "invalid permissions",
+        );
+        case(
+            &|e| {
+                e.hooks = Some(vec![CDIHook {
+                    hook_name: "bogus".into(),
+                    path: "/bin/true".into(),
+                    ..Default::default()
+                }])
+            },
+            "invalid hook name",
+        );
+        case(
+            &|e| {
+                e.hooks = Some(vec![CDIHook {
+                    hook_name: "prestart".into(),
+                    path: String::new(),
+                    ..Default::default()
+                }])
+            },
+            "empty path",
+        );
+        case(
+            &|e| {
+                e.hooks = Some(vec![CDIHook {
+                    hook_name: "prestart".into(),
+                    path: "/bin/true".into(),
+                    env: Some(vec!["BAD".into()]),
+                    ..Default::default()
+                }])
+            },
+            "invalid env",
+        );
+        case(
+            &|e| {
+                e.mounts = Some(vec![CDIMount {
+                    host_path: String::new(),
+                    container_path: "/c".into(),
+                    ..Default::default()
+                }])
+            },
+            "empty host path",
+        );
+        case(
+            &|e| {
+                e.mounts = Some(vec![CDIMount {
+                    host_path: "/h".into(),
+                    container_path: String::new(),
+                    ..Default::default()
+                }])
+            },
+            "empty container path",
+        );
+        case(
+            &|e| {
+                e.intel_rdt = Some(CDIIntelRdt {
+                    clos_id: Some("a/b".into()),
+                    ..Default::default()
+                })
+            },
+            "invalid clos id",
+        );
+    }
+
+    #[test]
+    fn validate_rejects_bad_net_devices() {
+        let netdev = |host: &str, name: &str| crate::specs::config::LinuxNetDevice {
+            host_interface_name: host.to_string(),
+            name: name.to_string(),
+        };
+        let case = |devices: Vec<crate::specs::config::LinuxNetDevice>, needle: &str| {
+            let mut edits = ContainerEdits::new();
+            edits.container_edits.net_devices = Some(devices);
+            let err = edits.validate().unwrap_err();
+            assert!(format!("{err:?}").contains(needle), "missing {needle:?}");
+        };
+
+        case(vec![netdev("", "eth0")], "empty HostInterfaceName");
+        case(vec![netdev("eth0", "")], "empty Name");
+        case(
+            vec![netdev("eth0", "a"), netdev("eth0", "b")],
+            "duplicate HostInterfaceName",
+        );
+        case(
+            vec![netdev("eth0", "a"), netdev("eth1", "a")],
+            "duplicate Name",
+        );
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "miri's stat shim does not populate rdev for /dev/null")]
+    fn fill_missing_info_rejects_host_type_mismatch() {
+        let mut dn = DeviceNode {
+            node: CDIDeviceNode {
+                path: "/dev/whatever".to_string(),
+                host_path: Some("/dev/null".to_string()),
+                r#type: Some("b".to_string()),
+                ..Default::default()
+            },
+        };
+        let err = dn.fill_missing_info().unwrap_err();
+        assert!(err.to_string().contains("host type mismatch"));
+    }
+
+    #[test]
+    fn fill_missing_info_returns_early_when_complete() {
+        let mut dn = DeviceNode {
+            node: named_device_node("/proc/does-not-matter", None),
+        };
+        // type + major present: no filesystem access happens at all
+        dn.fill_missing_info().unwrap();
+        assert_eq!(dn.node.major, Some(1));
+    }
 }

--- a/src/container_edits_unix.rs
+++ b/src/container_edits_unix.rs
@@ -256,4 +256,15 @@ mod tests {
         let result = dev_node.fill_missing_info();
         assert!(result.is_err());
     }
+
+    #[test]
+    fn create_device_reports_mknod_failures() {
+        if !is_root() {
+            println!("INFO: skipping, needs root");
+            return;
+        }
+        // mknod in a nonexistent directory fails: the error branch of the
+        // helper every root test depends on.
+        assert!(create_device("/nonexistent-dir/dev", 0o666, 0x0101, "b").is_err());
+    }
 }

--- a/src/container_edits_unix.rs
+++ b/src/container_edits_unix.rs
@@ -205,6 +205,41 @@ mod tests {
         assert_eq!(dev_node.node.minor, None);
     }
 
+    // No root needed: /dev/null exists everywhere as char 1:3.
+    #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "miri's stat shim does not populate rdev; /dev/null major/minor read as 0"
+    )]
+    fn device_info_from_char_device_without_root() {
+        let (typ, major, minor) = device_info_from_path("/dev/null").unwrap();
+        assert_eq!(typ, "c");
+        assert_eq!((major, minor), (1, 3));
+    }
+
+    // No root needed: mkfifo is an unprivileged syscall.
+    #[test]
+    #[cfg_attr(miri, ignore = "mkfifo is FFI miri cannot emulate")]
+    fn device_info_from_fifo_without_root() {
+        let temp_dir = TempDir::new().unwrap();
+        let fifo = temp_dir.path().join("fifo");
+        let path_c = CString::new(fifo.to_str().unwrap()).unwrap();
+        assert_eq!(unsafe { libc::mkfifo(path_c.as_ptr(), 0o600) }, 0);
+
+        let (typ, major, minor) = device_info_from_path(&fifo).unwrap();
+        assert_eq!(typ, "p");
+        assert_eq!((major, minor), (0, 0));
+    }
+
+    #[test]
+    fn device_info_rejects_regular_files() {
+        let temp_dir = TempDir::new().unwrap();
+        let file = temp_dir.path().join("plain");
+        std::fs::File::create(&file).unwrap();
+        let err = device_info_from_path(&file).unwrap_err();
+        assert!(err.to_string().contains("not a device node"));
+    }
+
     #[test]
     fn test_fill_missing_info_regular_file() {
         let temp_dir = TempDir::new().unwrap();

--- a/src/default_cache.rs
+++ b/src/default_cache.rs
@@ -8,21 +8,22 @@ use once_cell::sync::OnceCell;
 
 use crate::cache::{new_cache, with_auto_refresh, Cache, CdiOption};
 
-fn get_or_create_default_cache(_options: &[CdiOption]) -> Arc<Mutex<Cache>> {
-    let mut cache: OnceCell<Arc<Mutex<Cache>>> = OnceCell::new();
-    cache.get_or_init(|| {
-        let options: Vec<CdiOption> = vec![with_auto_refresh(true)];
-        new_cache(options)
-    });
-    cache.take().unwrap()
+// Process-wide: configure() and the query helpers must observe the same
+// instance, and auto-refresh state has to survive across calls.
+static DEFAULT_CACHE: OnceCell<Arc<Mutex<Cache>>> = OnceCell::new();
+
+fn get_or_create_default_cache() -> Arc<Mutex<Cache>> {
+    DEFAULT_CACHE
+        .get_or_init(|| new_cache(vec![with_auto_refresh(true)]))
+        .clone()
 }
 
 pub fn get_default_cache() -> Arc<Mutex<Cache>> {
-    get_or_create_default_cache(vec![].as_ref())
+    get_or_create_default_cache()
 }
 
 pub fn configure(options: Vec<CdiOption>) -> Result<()> {
-    let cache = get_or_create_default_cache(&options);
+    let cache = get_or_create_default_cache();
     let mut cache = cache.lock().unwrap();
     if options.is_empty() {
         return Ok(());
@@ -56,4 +57,56 @@ pub fn get_errors() -> HashMap<String, Vec<anyhow::Error>> {
     let cache = get_default_cache();
     let cache = cache.lock().unwrap();
     cache.get_errors()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::spec_dirs::with_spec_dirs;
+    use std::fs;
+
+    // One test covers the whole lifecycle: the cache is a process-wide
+    // singleton, so independent tests would race each other's state.
+    #[test]
+    fn default_cache_is_a_singleton_and_configurable() {
+        let first = get_default_cache();
+        let second = get_default_cache();
+        assert!(
+            Arc::ptr_eq(&first, &second),
+            "get_default_cache must return the same instance"
+        );
+
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("vendor.yaml"),
+            r#"cdiVersion: "0.6.0"
+kind: "vendor.com/device"
+devices:
+  - name: "gpu0"
+    containerEdits:
+      env:
+        - "VENDOR=1"
+"#,
+        )
+        .unwrap();
+
+        configure(vec![with_spec_dirs(&[dir.path().to_str().unwrap()])]).unwrap();
+        assert_eq!(
+            first.lock().unwrap().spec_dirs,
+            vec![dir.path().to_str().unwrap().to_string()],
+            "configure must act on the singleton"
+        );
+
+        // Empty configure is a no-op, not an error.
+        configure(vec![]).unwrap();
+
+        refresh().unwrap();
+        assert_eq!(list_devices(), vec!["vendor.com/device=gpu0".to_string()]);
+        assert!(get_errors().is_empty());
+
+        let mut oci_spec = Spec::default();
+        inject_devices(&mut oci_spec, vec!["vendor.com/device=gpu0".to_string()]).unwrap();
+        let env = oci_spec.process().as_ref().unwrap().env().as_ref().unwrap();
+        assert!(env.contains(&"VENDOR=1".to_string()));
+    }
 }

--- a/src/device.rs
+++ b/src/device.rs
@@ -103,3 +103,72 @@ impl Device {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        spec::new_spec,
+        specs::config::{
+            ContainerEdits as CDIContainerEdits, Device as CDIDeviceSpec, Spec as CDISpec,
+        },
+    };
+    use std::path::PathBuf;
+
+    fn spec_with(device: CDIDeviceSpec) -> Spec {
+        let raw = CDISpec {
+            version: "0.6.0".to_string(),
+            kind: "vendor.com/class".to_string(),
+            devices: vec![device.clone()],
+            ..Default::default()
+        };
+        new_spec(&raw, &PathBuf::from("/tmp/spec.yaml"), 0).unwrap()
+    }
+
+    fn cdi_device(name: &str) -> CDIDeviceSpec {
+        CDIDeviceSpec {
+            name: name.to_string(),
+            container_edits: CDIContainerEdits {
+                env: Some(vec!["X=1".to_string()]),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn new_device_builds_and_applies_edits() {
+        let raw = cdi_device("gpu0");
+        let spec = spec_with(raw.clone());
+        let mut device = new_device(&spec, &raw).unwrap();
+
+        assert_eq!(device.get_qualified_name(), "vendor.com/class=gpu0");
+        assert_eq!(device.get_spec().get_vendor(), "vendor.com");
+
+        let mut oci_spec = oci::Spec::default();
+        device.apply_edits(&mut oci_spec).unwrap();
+        let env = oci_spec.process().as_ref().unwrap().env().as_ref().unwrap();
+        assert!(env.contains(&"X=1".to_string()));
+    }
+
+    #[test]
+    fn new_device_rejects_invalid_names_and_empty_edits() {
+        let bad_name = cdi_device("not a name");
+        let spec = spec_with(cdi_device("gpu0"));
+        let err = new_device(&spec, &bad_name).unwrap_err();
+        assert!(err.to_string().contains("validate device name failed"));
+
+        let empty_edits = CDIDeviceSpec {
+            name: "gpu1".to_string(),
+            ..Default::default()
+        };
+        let err = new_device(&spec, &empty_edits).unwrap_err();
+        assert!(err.to_string().contains("empty device edits"));
+    }
+
+    #[test]
+    fn default_device_is_constructible() {
+        let device = Device::default();
+        assert_eq!(device.cdi_device.name, "");
+    }
+}

--- a/src/generate/config.rs
+++ b/src/generate/config.rs
@@ -26,82 +26,73 @@ impl Generator {
     pub fn init_config_process(&mut self) {
         self.init_config();
 
-        if let Some(spec) = self.config.as_mut() {
-            if spec.process().is_none() {
-                spec.set_process(Some(Process::default()));
-            }
+        let spec = self.config.as_mut().unwrap();
+        if spec.process().is_none() {
+            spec.set_process(Some(Process::default()));
         }
     }
 
     pub fn init_config_linux(&mut self) {
         self.init_config();
 
-        if let Some(spec) = self.config.as_mut() {
-            if spec.linux().is_none() {
-                spec.set_linux(Some(Linux::default()));
-            }
+        let spec = self.config.as_mut().unwrap();
+        if spec.linux().is_none() {
+            spec.set_linux(Some(Linux::default()));
         }
     }
 
     pub fn init_config_linux_resources(&mut self) {
         self.init_config_linux();
 
-        if let Some(linux) = self.config.as_mut().unwrap().linux_mut() {
-            if linux.resources().is_none() {
-                linux.set_resources(Some(LinuxResources::default()));
-            }
+        let linux = self.config.as_mut().unwrap().linux_mut().as_mut().unwrap();
+        if linux.resources().is_none() {
+            linux.set_resources(Some(LinuxResources::default()));
         }
     }
 
     pub fn init_config_linux_resources_devices(&mut self) {
         self.init_config_linux_resources();
 
-        if let Some(linux) = self.config.as_mut().unwrap().linux_mut() {
-            if let Some(resource) = linux.resources_mut() {
-                if resource.devices().is_none() {
-                    resource.set_devices(Some(Vec::new()));
-                }
-            }
+        let linux = self.config.as_mut().unwrap().linux_mut().as_mut().unwrap();
+        let resource = linux.resources_mut().as_mut().unwrap();
+        if resource.devices().is_none() {
+            resource.set_devices(Some(Vec::new()));
         }
     }
 
     pub fn init_config_linux_net_devices(&mut self) {
         self.init_config_linux();
 
-        if let Some(linux) = self.config.as_mut().unwrap().linux_mut() {
-            if linux.net_devices().is_none() {
-                linux.set_net_devices(Some(HashMap::new()));
-            }
+        let linux = self.config.as_mut().unwrap().linux_mut().as_mut().unwrap();
+        if linux.net_devices().is_none() {
+            linux.set_net_devices(Some(HashMap::new()));
         }
     }
 
     pub fn init_config_hooks(&mut self) {
         self.init_config();
 
-        if let Some(spec) = self.config.as_mut() {
-            if spec.hooks().is_none() {
-                spec.set_hooks(Some(Hooks::default()));
-            }
+        let spec = self.config.as_mut().unwrap();
+        if spec.hooks().is_none() {
+            spec.set_hooks(Some(Hooks::default()));
         }
     }
 
     pub fn init_config_mounts(&mut self) {
         self.init_config();
 
-        if let Some(spec) = self.config.as_mut() {
-            if spec.mounts().is_none() {
-                spec.set_mounts(Some(vec![Mount::default()]));
-            }
+        let spec = self.config.as_mut().unwrap();
+        if spec.mounts().is_none() {
+            spec.set_mounts(Some(vec![Mount::default()]));
         }
     }
 
     pub fn init_config_linux_intel_rdt(&mut self) {
         self.init_config_linux();
 
-        if let Some(linux) = self.config.as_mut().unwrap().linux_mut() {
-            if linux.intel_rdt().is_none() {
-                linux.set_intel_rdt(Some(LinuxIntelRdt::default()));
-            }
+        let linux = self.config.as_mut().unwrap().linux_mut().as_mut().unwrap();
+        if linux.intel_rdt().is_none() {
+            linux.set_intel_rdt(Some(LinuxIntelRdt::default()));
         }
     }
 }
@@ -114,28 +105,60 @@ mod tests {
     // calling twice exercises both branches.
     #[test]
     fn init_helpers_are_idempotent() {
-        let mut g = Generator::spec_gen(None);
-        g.init_config();
-        assert!(g.config.is_some());
+        // An all-None spec drives the create arms (serde defaults would
+        // repopulate, hence explicit setters); the second loop pass and the
+        // pre-populated Spec::default() drive the leave-alone arms.
+        let mut bare = Spec::default();
+        bare.set_process(None)
+            .set_linux(None)
+            .set_hooks(None)
+            .set_mounts(None);
+        // Linux::default() pre-populates resources: hollow it out layer by
+        // layer so the set_resources / set_devices create arms fire too.
+        let mut hollow_linux = Linux::default();
+        hollow_linux
+            .set_resources(None)
+            .set_net_devices(None)
+            .set_intel_rdt(None);
+        let mut spec_hollow_linux = Spec::default();
+        spec_hollow_linux.set_linux(Some(hollow_linux));
+        let mut resources_no_devices = LinuxResources::default();
+        resources_no_devices.set_devices(None);
+        let mut linux_no_devices = Linux::default();
+        linux_no_devices.set_resources(Some(resources_no_devices));
+        let mut spec_no_devices = Spec::default();
+        spec_no_devices.set_linux(Some(linux_no_devices));
 
-        for _ in 0..2 {
-            g.init_config_process();
-            g.init_config_linux();
-            g.init_config_linux_resources();
-            g.init_config_linux_resources_devices();
-            g.init_config_linux_net_devices();
-            g.init_config_hooks();
-            g.init_config_mounts();
-            g.init_config_linux_intel_rdt();
+        for spec in [
+            Some(bare),
+            Some(spec_hollow_linux),
+            Some(spec_no_devices),
+            None,
+            Some(Spec::default()),
+        ] {
+            let mut g = Generator::spec_gen(spec);
+            g.init_config();
+            assert!(g.config.is_some());
+
+            for _ in 0..2 {
+                g.init_config_process();
+                g.init_config_linux();
+                g.init_config_linux_resources();
+                g.init_config_linux_resources_devices();
+                g.init_config_linux_net_devices();
+                g.init_config_hooks();
+                g.init_config_mounts();
+                g.init_config_linux_intel_rdt();
+            }
+
+            let spec = g.config.as_ref().unwrap();
+            assert!(spec.process().is_some());
+            assert!(spec.hooks().is_some());
+            assert!(spec.mounts().is_some());
+            let linux = spec.linux().as_ref().unwrap();
+            assert!(linux.resources().as_ref().unwrap().devices().is_some());
+            assert!(linux.net_devices().is_some());
+            assert!(linux.intel_rdt().is_some());
         }
-
-        let spec = g.config.as_ref().unwrap();
-        assert!(spec.process().is_some());
-        assert!(spec.hooks().is_some());
-        assert!(spec.mounts().is_some());
-        let linux = spec.linux().as_ref().unwrap();
-        assert!(linux.resources().as_ref().unwrap().devices().is_some());
-        assert!(linux.net_devices().is_some());
-        assert!(linux.intel_rdt().is_some());
     }
 }

--- a/src/generate/config.rs
+++ b/src/generate/config.rs
@@ -105,3 +105,37 @@ impl Generator {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Each init_* must create the layer once and leave it alone after -
+    // calling twice exercises both branches.
+    #[test]
+    fn init_helpers_are_idempotent() {
+        let mut g = Generator::spec_gen(None);
+        g.init_config();
+        assert!(g.config.is_some());
+
+        for _ in 0..2 {
+            g.init_config_process();
+            g.init_config_linux();
+            g.init_config_linux_resources();
+            g.init_config_linux_resources_devices();
+            g.init_config_linux_net_devices();
+            g.init_config_hooks();
+            g.init_config_mounts();
+            g.init_config_linux_intel_rdt();
+        }
+
+        let spec = g.config.as_ref().unwrap();
+        assert!(spec.process().is_some());
+        assert!(spec.hooks().is_some());
+        assert!(spec.mounts().is_some());
+        let linux = spec.linux().as_ref().unwrap();
+        assert!(linux.resources().as_ref().unwrap().devices().is_some());
+        assert!(linux.net_devices().is_some());
+        assert!(linux.intel_rdt().is_some());
+    }
+}

--- a/src/generate/generator.rs
+++ b/src/generate/generator.rs
@@ -288,7 +288,179 @@ impl Eq for OrderedMounts {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use oci_spec::runtime::LinuxNetDevice;
+    use oci_spec::runtime::{LinuxNetDevice, Spec};
+
+    fn gen() -> Generator {
+        Generator::spec_gen(Some(Spec::default()))
+    }
+
+    #[test]
+    fn add_device_inserts_replaces_and_remove_deletes() {
+        let mut g = gen();
+        let mut dev = LinuxDevice::default();
+        dev.set_path(PathBuf::from("/dev/x"));
+        g.add_device(dev.clone());
+
+        // same path replaces instead of duplicating
+        let mut replacement = LinuxDevice::default();
+        replacement.set_path(PathBuf::from("/dev/x"));
+        replacement.set_major(7);
+        g.add_device(replacement);
+
+        let devices = |g: &Generator| {
+            g.config
+                .as_ref()
+                .unwrap()
+                .linux()
+                .as_ref()
+                .unwrap()
+                .devices()
+                .clone()
+                .unwrap_or_default()
+        };
+        assert_eq!(devices(&g).len(), 1);
+        assert_eq!(devices(&g)[0].major(), 7);
+
+        g.remove_device("/dev/x");
+        assert!(devices(&g).is_empty());
+        // removing an absent device is a no-op
+        g.remove_device("/dev/x");
+    }
+
+    #[test]
+    fn add_linux_resources_device_records_cgroup_entry() {
+        let mut g = gen();
+        g.add_linux_resources_device(
+            true,
+            LinuxDeviceType::C,
+            Some(1),
+            Some(3),
+            Some("rwm".to_string()),
+        );
+
+        let binding = g.config.unwrap();
+        let devices = binding
+            .linux()
+            .as_ref()
+            .unwrap()
+            .resources()
+            .as_ref()
+            .unwrap()
+            .devices()
+            .as_ref()
+            .unwrap();
+        assert_eq!(devices.len(), 1);
+        assert!(devices[0].allow());
+        assert_eq!(devices[0].typ(), Some(LinuxDeviceType::C));
+        assert_eq!(devices[0].major(), Some(1));
+        assert_eq!(devices[0].minor(), Some(3));
+        assert_eq!(devices[0].access().as_deref(), Some("rwm"));
+    }
+
+    #[test]
+    fn intel_rdt_set_and_clos_id_update() {
+        let mut g = gen();
+        let mut rdt = LinuxIntelRdt::default();
+        rdt.set_clos_id(Some("initial".to_string()));
+        g.set_linux_intel_rdt(rdt);
+        g.set_linux_intel_rdt_clos_id("updated".to_string());
+
+        let binding = g.config.unwrap();
+        let rdt = binding
+            .linux()
+            .as_ref()
+            .unwrap()
+            .intel_rdt()
+            .as_ref()
+            .unwrap();
+        assert_eq!(rdt.clos_id().as_deref(), Some("updated"));
+    }
+
+    #[test]
+    fn additional_gids_deduplicate() {
+        let mut g = gen();
+        g.add_process_additional_gid(1000);
+        g.add_process_additional_gid(1000);
+        g.add_process_additional_gid(2000);
+
+        let binding = g.config.unwrap();
+        let gids = binding
+            .process()
+            .as_ref()
+            .unwrap()
+            .user()
+            .additional_gids()
+            .clone()
+            .unwrap();
+        assert_eq!(gids, vec![1000, 2000]);
+    }
+
+    #[test]
+    fn env_updates_existing_keys_and_appends_new_ones() {
+        let mut g = gen();
+        g.add_multiple_process_env(&["A=1".to_string(), "B=2".to_string()]);
+        g.add_multiple_process_env(&["A=3".to_string(), "C=4".to_string()]);
+
+        let binding = g.config.unwrap();
+        let env = binding.process().as_ref().unwrap().env().clone().unwrap();
+        // Spec::default() seeds PATH/TERM; assert semantics, not the seed.
+        assert_eq!(env.iter().filter(|e| e.starts_with("A=")).count(), 1);
+        let tail = &env[env.len() - 3..];
+        assert_eq!(tail, ["A=3", "B=2", "C=4"]);
+    }
+
+    #[test]
+    fn hooks_initialize_then_append() {
+        let mut g = gen();
+        for _ in 0..2 {
+            g.add_prestart_hook(Hook::default());
+            g.add_poststart_hook(Hook::default());
+            g.add_poststop_hook(Hook::default());
+            g.add_createruntime_hook(Hook::default());
+            g.add_createcontainer_hook(Hook::default());
+            g.add_startcontainer_hook(Hook::default());
+        }
+
+        let binding = g.config.unwrap();
+        let hooks = binding.hooks().as_ref().unwrap();
+        assert_eq!(hooks.prestart().as_ref().unwrap().len(), 2);
+        assert_eq!(hooks.poststart().as_ref().unwrap().len(), 2);
+        assert_eq!(hooks.poststop().as_ref().unwrap().len(), 2);
+        assert_eq!(hooks.create_runtime().as_ref().unwrap().len(), 2);
+        assert_eq!(hooks.create_container().as_ref().unwrap().len(), 2);
+        assert_eq!(hooks.start_container().as_ref().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn mounts_add_sort_list_remove_clear() {
+        let mut g = gen();
+        let mount = |dest: &str| {
+            let mut m = Mount::default();
+            m.set_destination(PathBuf::from(dest));
+            m
+        };
+        g.add_mount(mount("/z"));
+        g.add_mount(mount("/a"));
+
+        g.sort_mounts();
+        let dests: Vec<_> = g
+            .list_mounts()
+            .unwrap()
+            .iter()
+            .map(|m| m.destination().clone())
+            .collect();
+        assert!(dests.windows(2).all(|w| w[0] <= w[1]));
+
+        g.remove_mount("/z");
+        assert!(!g
+            .list_mounts()
+            .unwrap()
+            .iter()
+            .any(|m| m.destination() == &PathBuf::from("/z")));
+
+        g.clear_mounts();
+        assert!(g.list_mounts().is_none());
+    }
 
     #[test]
     fn add_process_additional_gid_initializes_empty_gid_list() {

--- a/src/generate/generator.rs
+++ b/src/generate/generator.rs
@@ -505,4 +505,73 @@ mod tests {
             "container_eth0"
         );
     }
+
+    // An all-None spec (unlike Spec::default(), which comes pre-populated)
+    // drives the create-the-layer arms of every add_/init_ helper.
+    fn empty_gen() -> Generator {
+        let mut bare = Spec::default();
+        bare.set_process(None)
+            .set_linux(None)
+            .set_hooks(None)
+            .set_mounts(None);
+        Generator::spec_gen(Some(bare))
+    }
+
+    #[test]
+    fn helpers_create_missing_layers_on_empty_specs() {
+        let mut g = empty_gen();
+        let mut dev = LinuxDevice::default();
+        dev.set_path(PathBuf::from("/dev/x"));
+        g.remove_device("/dev/x"); // no devices list yet: no-op arm
+        g.add_device(dev);
+        g.add_linux_resources_device(true, LinuxDeviceType::C, Some(1), Some(3), None);
+        let mut net_device = LinuxNetDevice::default();
+        net_device.set_name(Some("c".to_string()));
+        g.add_linux_net_device("eth0".to_string(), net_device);
+        g.set_linux_intel_rdt_clos_id("clos".to_string());
+        g.add_process_additional_gid(9);
+        g.add_multiple_process_env(&["K=V".to_string()]);
+        g.add_prestart_hook(Hook::default());
+        g.add_poststart_hook(Hook::default());
+        g.add_poststop_hook(Hook::default());
+        g.add_createruntime_hook(Hook::default());
+        g.add_createcontainer_hook(Hook::default());
+        g.add_startcontainer_hook(Hook::default());
+        g.add_mount(Mount::default());
+        g.sort_mounts();
+        g.clear_mounts();
+        assert!(g.list_mounts().is_none());
+
+        let binding = g.config.unwrap();
+        assert_eq!(
+            binding
+                .linux()
+                .as_ref()
+                .unwrap()
+                .devices()
+                .as_ref()
+                .unwrap()
+                .len(),
+            1
+        );
+        assert!(binding.hooks().is_some());
+    }
+
+    #[test]
+    fn ordered_mounts_compare_by_depth_then_path() {
+        let mount = |dest: &str| {
+            let mut m = Mount::default();
+            m.set_destination(PathBuf::from(dest));
+            m
+        };
+        let shallow = OrderedMounts::new(vec![mount("/a")]);
+        let deep = OrderedMounts::new(vec![mount("/a/b")]);
+        let deep_b = OrderedMounts::new(vec![mount("/a/c")]);
+
+        assert!(shallow < deep);
+        assert!(deep < deep_b);
+        assert_eq!(deep.partial_cmp(&deep_b), Some(Ordering::Less));
+        assert_eq!(shallow.parts(0), 2);
+        assert!(shallow == OrderedMounts::new(vec![mount("/a")]));
+    }
 }

--- a/src/internal/validation/k8s/validation.rs
+++ b/src/internal/validation/k8s/validation.rs
@@ -63,7 +63,7 @@ pub fn is_qualified_name(value: &str) -> Vec<String> {
                 errs.push(format!("prefix part {}", empty_error()));
             } else {
                 let msgs = is_dns1123_subdomain(prefix);
-                if msgs.is_empty() {
+                if !msgs.is_empty() {
                     errs.extend(prefix_each(&msgs, "prefix part "));
                 }
             }
@@ -211,4 +211,78 @@ fn prefix_each(msgs: &[String], prefix: &str) -> Vec<String> {
 #[allow(dead_code)]
 fn inclusive_range_error(lo: usize, hi: usize) -> String {
     format!("must be between {} and {}, inclusive", lo, hi)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn qualified_names_accept_valid_forms() {
+        for name in ["simple", "my.name", "123-abc", "example.com/MyName"] {
+            assert!(is_qualified_name(name).is_empty(), "{name} should be valid");
+        }
+    }
+
+    #[test]
+    fn qualified_names_reject_invalid_name_part() {
+        assert!(!is_qualified_name("").is_empty());
+        assert!(!is_qualified_name("-leading.dash").is_empty());
+        assert!(!is_qualified_name(&"x".repeat(64)).is_empty());
+        assert!(!is_qualified_name("a/b/c").is_empty());
+        assert!(!is_qualified_name("/name").is_empty());
+    }
+
+    // Regression: prefix errors were dropped (inverted is_empty check), so
+    // an invalid DNS-1123 prefix used to validate successfully.
+    #[test]
+    fn qualified_names_reject_invalid_prefix() {
+        let errs = is_qualified_name("Bad_Prefix/name");
+        assert!(
+            errs.iter().any(|e| e.starts_with("prefix part ")),
+            "invalid prefix must produce a prefix error, got: {errs:?}"
+        );
+    }
+
+    #[test]
+    fn label_values() {
+        assert!(is_valid_label_value("").is_empty());
+        assert!(is_valid_label_value("MyValue").is_empty());
+        assert!(!is_valid_label_value("no spaces").is_empty());
+        assert!(!is_valid_label_value(&"x".repeat(64)).is_empty());
+    }
+
+    #[test]
+    fn dns1123_labels_and_subdomains() {
+        assert!(is_dns1123_label("my-name").is_empty());
+        assert!(!is_dns1123_label("My-Name").is_empty());
+        assert!(!is_dns1123_label(&"x".repeat(64)).is_empty());
+        assert!(is_dns1123_subdomain("example.com").is_empty());
+        assert!(!is_dns1123_subdomain("Example.com").is_empty());
+        assert!(!is_dns1123_subdomain(&"x".repeat(254)).is_empty());
+    }
+
+    #[test]
+    fn dns1035_labels() {
+        assert!(is_dns1035_label("abc-123").is_empty());
+        assert!(!is_dns1035_label("1abc").is_empty());
+        assert!(!is_dns1035_label(&"x".repeat(64)).is_empty());
+    }
+
+    #[test]
+    fn wildcard_subdomains() {
+        assert!(is_wildcard_dns1123_subdomain("*.example.com").is_empty());
+        assert!(!is_wildcard_dns1123_subdomain("example.com").is_empty());
+        assert!(!is_wildcard_dns1123_subdomain(&format!("*.{}", "x".repeat(253))).is_empty());
+    }
+
+    #[test]
+    fn error_message_helpers() {
+        assert!(regex_error("msg", "fmt", &[]).contains("regex used for validation"));
+        assert!(regex_error("msg", "fmt", &["ex"]).contains("e.g. 'ex'"));
+        assert_eq!(
+            inclusive_range_error(1, 5),
+            "must be between 1 and 5, inclusive"
+        );
+    }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -281,4 +281,37 @@ mod tests {
         assert!(parser::validate_device_name("_gpu").is_err());
         assert!(parser::validate_device_name("gpu_").is_err());
     }
+
+    #[test]
+    fn qualified_name_detection_both_ways() {
+        assert!(parser::is_qualified_name("vendor.com/class=dev"));
+        assert!(!parser::is_qualified_name("/dev/null"));
+    }
+
+    #[test]
+    fn parse_qualified_name_rejects_malformed_input() {
+        for (input, needle) in [
+            ("", "missing vendor"),
+            ("/dev/null", "missing vendor"),
+            ("class=dev", "missing vendor"),
+            ("vendor.com/class", "missing vendor"),
+            ("vendor.com/class=", "missing vendor"),
+            ("_vendor/class=dev", "invalid vendor"),
+            ("vendor.com/cl*ss=dev", "invalid class"),
+            ("vendor.com/class=dev name", "invalid device"),
+        ] {
+            let err = parser::parse_qualified_name(input).unwrap_err();
+            assert!(
+                err.to_string().contains(needle),
+                "{input:?}: expected {needle:?} in {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_qualifier_splits_or_returns_verbatim() {
+        assert_eq!(parser::parse_qualifier("vendor/class"), ("vendor", "class"));
+        assert_eq!(parser::parse_qualifier("noslash"), ("", "noslash"));
+        assert_eq!(parser::parse_qualifier("vendor/"), ("", "vendor/"));
+    }
 }

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -21,7 +21,9 @@ use crate::{
     },
 };
 
-const DEFAULT_SPEC_EXT_SUFFIX: &str = ".yaml";
+// No leading dot: Path::set_extension takes the extension itself; a
+// dotted value produces "spec..yaml".
+const DEFAULT_SPEC_EXT_SUFFIX: &str = "yaml";
 
 // Spec represents a single CDI Spec. It is usually loaded from a
 // file and stored in a cache. The Spec has an associated priority.
@@ -270,5 +272,83 @@ mod tests {
         let err = format!("{err:?}");
 
         assert!(err.contains("empty device edits"), "{err}");
+    }
+
+    fn one_device(name: &str) -> crate::specs::config::Device {
+        crate::specs::config::Device {
+            name: name.to_string(),
+            container_edits: crate::specs::config::ContainerEdits {
+                env: Some(vec!["X=1".to_string()]),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn new_spec_rejects_duplicate_device_names() {
+        let raw = crate::specs::config::Spec {
+            version: "0.6.0".to_string(),
+            kind: "vendor.com/device".to_string(),
+            devices: vec![one_device("d0"), one_device("d0")],
+            ..Default::default()
+        };
+        let err = new_spec(&raw, &PathBuf::from("/tmp/x.yaml"), 0).unwrap_err();
+        assert!(format!("{err:?}").contains("multiple device"));
+    }
+
+    #[test]
+    fn new_spec_normalizes_non_spec_extensions() {
+        let raw = crate::specs::config::Spec {
+            version: "0.6.0".to_string(),
+            kind: "vendor.com/device".to_string(),
+            devices: vec![one_device("d0")],
+            ..Default::default()
+        };
+        let spec = new_spec(&raw, &PathBuf::from("/tmp/spec.conf"), 0).unwrap();
+        assert!(spec.get_path().ends_with("spec.yaml"));
+    }
+
+    #[test]
+    fn spec_level_edits_apply_to_oci_spec() {
+        let raw = crate::specs::config::Spec {
+            version: "0.6.0".to_string(),
+            kind: "vendor.com/device".to_string(),
+            container_edits: Some(crate::specs::config::ContainerEdits {
+                env: Some(vec!["GLOBAL=1".to_string()]),
+                ..Default::default()
+            }),
+            devices: vec![one_device("d0")],
+            ..Default::default()
+        };
+        let mut spec = new_spec(&raw, &PathBuf::from("/tmp/x.yaml"), 0).unwrap();
+        let mut oci_spec = oci::Spec::default();
+        spec.apply_edits(&mut oci_spec).unwrap();
+        let env = oci_spec.process().as_ref().unwrap().env().as_ref().unwrap();
+        assert!(env.contains(&"GLOBAL=1".to_string()));
+    }
+
+    #[test]
+    fn parse_spec_requires_an_existing_path() {
+        let err = parse_spec(&PathBuf::from("/nonexistent/spec.yaml")).unwrap_err();
+        assert!(err.to_string().contains("not found"));
+    }
+
+    #[test]
+    fn validate_version_rejects_unknown_and_understated_versions() {
+        let mut raw = crate::specs::config::Spec {
+            version: "9.9.9".to_string(),
+            kind: "vendor.com/device".to_string(),
+            devices: vec![one_device("d0")],
+            ..Default::default()
+        };
+        let err = new_spec(&raw, &PathBuf::from("/tmp/x.yaml"), 0).unwrap_err();
+        assert!(format!("{err:?}").contains("invalid version"));
+
+        // additionalGIDs require 0.7.0: declaring 0.5.0 understates it
+        raw.version = "0.5.0".to_string();
+        raw.devices[0].container_edits.additional_gids = Some(vec![5]);
+        let err = new_spec(&raw, &PathBuf::from("/tmp/x.yaml"), 0).unwrap_err();
+        assert!(format!("{err:?}").contains("must be at least"));
     }
 }

--- a/src/spec_dirs.rs
+++ b/src/spec_dirs.rs
@@ -145,5 +145,81 @@ pub(crate) fn scan_spec_dirs<P: AsRef<Path>>(dirs: &[P]) -> Result<Vec<Spec>, Bo
 
 #[cfg(test)]
 mod tests {
-    //TODO
+    use super::*;
+    use std::collections::HashMap;
+    use std::fs;
+
+    const SPEC_YAML: &str = r#"cdiVersion: "0.6.0"
+kind: "vendor.com/device"
+devices:
+  - name: "gpu0"
+    containerEdits:
+      env:
+        - "VENDOR=1"
+"#;
+
+    const SPEC_JSON: &str = r#"{
+  "cdiVersion": "0.6.0",
+  "kind": "vendor2.com/device",
+  "devices": [
+    { "name": "d0", "containerEdits": { "env": ["OTHER=1"] } }
+  ]
+}"#;
+
+    #[test]
+    fn with_spec_dirs_cleans_paths() {
+        let mut cache = Cache::default();
+        with_spec_dirs(&["/etc/cdi/../cdi", "/var/run/cdi/"])(&mut cache);
+        assert_eq!(cache.spec_dirs, vec!["/etc/cdi", "/var/run/cdi"]);
+    }
+
+    #[test]
+    fn spec_error_display_and_conversion() {
+        let mut errors: HashMap<String, Vec<Box<dyn Error>>> = HashMap::new();
+        errors.insert(
+            "/etc/cdi/broken.yaml".to_string(),
+            vec![Box::new(SpecError::new("bad spec"))],
+        );
+
+        let converted = convert_errors(&errors);
+        let msgs = &converted["/etc/cdi/broken.yaml"];
+        assert_eq!(msgs.len(), 1);
+        assert!(msgs[0].to_string().contains("bad spec"));
+    }
+
+    #[test]
+    fn scan_finds_specs_recursively_with_dir_index_as_priority() {
+        let low = tempfile::tempdir().unwrap();
+        let high = tempfile::tempdir().unwrap();
+        fs::write(low.path().join("vendor.yaml"), SPEC_YAML).unwrap();
+        // json spec in a nested subdir: traversal must descend
+        let nested = high.path().join("nested");
+        fs::create_dir(&nested).unwrap();
+        fs::write(nested.join("vendor2.json"), SPEC_JSON).unwrap();
+        // non-spec files are ignored
+        fs::write(high.path().join("README.txt"), "not a spec").unwrap();
+
+        let specs = scan_spec_dirs(&[low.path(), high.path()]).unwrap();
+
+        assert_eq!(specs.len(), 2);
+        let by_vendor: HashMap<_, _> = specs
+            .iter()
+            .map(|s| (s.get_vendor().to_string(), s.get_priority()))
+            .collect();
+        assert_eq!(by_vendor["vendor.com"], 0);
+        assert_eq!(by_vendor["vendor2.com"], 1);
+    }
+
+    #[test]
+    fn scan_skips_missing_dirs() {
+        let specs = scan_spec_dirs(&["/nonexistent/cdi/dir"]).unwrap();
+        assert!(specs.is_empty());
+    }
+
+    #[test]
+    fn scan_fails_on_invalid_spec() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("broken.yaml"), "cdiVersion: [not a spec").unwrap();
+        assert!(scan_spec_dirs(&[dir.path()]).is_err());
+    }
 }

--- a/src/version.rs
+++ b/src/version.rs
@@ -403,4 +403,129 @@ mod tests {
             "1.1.0"
         );
     }
+
+    #[test]
+    fn v110_specs_reject_legacy_intel_rdt_fields() {
+        for (cmt, mbm, needle) in [
+            (Some(true), None, "enableCMT"),
+            (None, Some(true), "enableMBM"),
+        ] {
+            let spec = CDISpec {
+                version: V110.to_string(),
+                kind: "vendor.com/device".to_string(),
+                container_edits: Some(ContainerEdits {
+                    intel_rdt: Some(IntelRdt {
+                        enable_cmt: cmt,
+                        enable_mbm: mbm,
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            };
+            let err = validate_declared_version_fields(&spec).unwrap_err();
+            assert!(err.to_string().contains(needle), "{err}");
+        }
+    }
+
+    #[test]
+    fn pre_v110_specs_reject_net_devices() {
+        let spec = CDISpec {
+            version: V070.to_string(),
+            kind: "vendor.com/device".to_string(),
+            container_edits: Some(ContainerEdits {
+                net_devices: Some(vec![LinuxNetDevice {
+                    host_interface_name: "eth0".to_string(),
+                    name: "c_eth0".to_string(),
+                }]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let err = validate_declared_version_fields(&spec).unwrap_err();
+        assert!(err.to_string().contains("netDevices requires"), "{err}");
+    }
+
+    #[test]
+    fn device_level_edits_drive_required_versions() {
+        let with_device_edits = |edits: ContainerEdits| CDISpec {
+            version: VCURRENT.to_string(),
+            kind: "vendor.com/device".to_string(),
+            devices: vec![Device {
+                name: "d0".to_string(),
+                container_edits: edits,
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        // device-level intelRdt (clos only) -> 0.7.0
+        let spec = with_device_edits(ContainerEdits {
+            intel_rdt: Some(IntelRdt {
+                clos_id: Some("c".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        });
+        assert_eq!(
+            minimum_required_version(&spec).unwrap().to_string(),
+            "0.7.0"
+        );
+
+        // device-level netDevices -> 1.1.0
+        let spec = with_device_edits(ContainerEdits {
+            net_devices: Some(vec![LinuxNetDevice {
+                host_interface_name: "eth0".to_string(),
+                name: "c".to_string(),
+            }]),
+            ..Default::default()
+        });
+        assert_eq!(
+            minimum_required_version(&spec).unwrap().to_string(),
+            "1.1.0"
+        );
+
+        // device-level additionalGIDs -> 0.7.0
+        let spec = with_device_edits(ContainerEdits {
+            additional_gids: Some(vec![5]),
+            ..Default::default()
+        });
+        assert_eq!(
+            minimum_required_version(&spec).unwrap().to_string(),
+            "0.7.0"
+        );
+    }
+
+    #[test]
+    fn annotations_and_dotted_class_require_v060() {
+        let mut spec = CDISpec {
+            version: VCURRENT.to_string(),
+            kind: "vendor.com/device".to_string(),
+            ..Default::default()
+        };
+        spec.annotations.insert("k".to_string(), "v".to_string());
+        assert_eq!(
+            minimum_required_version(&spec).unwrap().to_string(),
+            "0.6.0"
+        );
+
+        let mut spec = CDISpec {
+            version: VCURRENT.to_string(),
+            kind: "vendor.com/class.with.dots".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(
+            minimum_required_version(&spec).unwrap().to_string(),
+            "0.6.0"
+        );
+        spec.devices = vec![Device {
+            name: "d0".to_string(),
+            annotations: [("a".to_string(), "b".to_string())].into(),
+            ..Default::default()
+        }];
+        assert_eq!(
+            minimum_required_version(&spec).unwrap().to_string(),
+            "0.6.0"
+        );
+    }
 }

--- a/tests/cdi_cli.rs
+++ b/tests/cdi_cli.rs
@@ -1,0 +1,79 @@
+// Spawns the cdi binary; miri cannot emulate process creation.
+#![cfg(not(miri))]
+
+use std::{fs, process::Command};
+
+fn cdi_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_cdi")
+}
+
+#[test]
+fn cdi_cli_help_succeeds() {
+    let output = Command::new(cdi_bin()).arg("--help").output().unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("devices"));
+    assert!(stdout.contains("inject"));
+}
+
+#[test]
+fn cdi_cli_lists_devices() {
+    let output = Command::new(cdi_bin()).arg("devices").output().unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // The default cache scans /etc/cdi and /var/run/cdi; both outcomes are
+    // legitimate depending on the host.
+    assert!(
+        stdout.contains("No CDI devices found") || stdout.contains("CDI devices found"),
+        "unexpected output: {stdout}"
+    );
+}
+
+#[test]
+fn cdi_cli_lists_devices_verbose_json() {
+    let output = Command::new(cdi_bin())
+        .args(["devices", "--verbose", "--output", "json"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+}
+
+#[test]
+fn cdi_cli_inject_rejects_missing_oci_spec() {
+    let output = Command::new(cdi_bin())
+        .args([
+            "inject",
+            "/nonexistent/spec.yaml",
+            "vendor.example/none=missing",
+        ])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("path of oci spec not found"), "{stderr}");
+}
+
+#[test]
+fn cdi_cli_inject_updates_an_oci_spec() {
+    let dir = tempfile::tempdir().unwrap();
+    let spec = dir.path().join("oci.yaml");
+    fs::write(&spec, "ociVersion: \"1.0.2\"\n").unwrap();
+
+    // Unknown device patterns are filtered out (not an error): the spec is
+    // echoed back updated-but-unchanged.
+    let output = Command::new(cdi_bin())
+        .args([
+            "inject",
+            spec.to_str().unwrap(),
+            "vendor.example/none=missing",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Updated OCI Spec:"), "{stdout}");
+}

--- a/tests/validate_cli.rs
+++ b/tests/validate_cli.rs
@@ -186,3 +186,90 @@ fn validate_cli_rejects_cdi_schema_without_defs_json() {
         String::from_utf8_lossy(&output.stderr)
     );
 }
+
+#[test]
+fn validate_cli_accepts_schema_none() {
+    let output = Command::new(validate_bin())
+        .args(["--schema", "none"])
+        .arg(manifest_path("tests/fixtures/cdi-v1.1-good.yaml"))
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{:?}", output);
+}
+
+#[test]
+fn validate_cli_reads_document_from_stdin() {
+    use std::io::Write;
+    use std::process::Stdio;
+
+    let mut child = Command::new(validate_bin())
+        .args(["--schema", "builtin", "-"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(&std::fs::read(manifest_path("tests/fixtures/cdi-v1.1-good.yaml")).unwrap())
+        .unwrap();
+    let output = child.wait_with_output().unwrap();
+    assert!(output.status.success(), "{:?}", output);
+}
+
+#[test]
+fn validate_cli_uses_sibling_defs_json_for_custom_schema() {
+    let dir = tempfile::tempdir().unwrap();
+    let manifest = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    std::fs::copy(
+        manifest.join("src/schema/schema.json"),
+        dir.path().join("schema.json"),
+    )
+    .unwrap();
+    std::fs::copy(
+        manifest.join("src/schema/defs.json"),
+        dir.path().join("defs.json"),
+    )
+    .unwrap();
+
+    let output = Command::new(validate_bin())
+        .args(["--schema", dir.path().join("schema.json").to_str().unwrap()])
+        .arg(manifest_path("tests/fixtures/cdi-v1.1-good.yaml"))
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{:?}", output);
+}
+
+#[test]
+fn validate_cli_rejects_schema_referencing_missing_defs() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("schema.json"),
+        r##"{"type": "object", "properties": {"x": {"$ref": "defs.json#/defs/foo"}}}"##,
+    )
+    .unwrap();
+
+    let output = Command::new(validate_bin())
+        .args(["--schema", dir.path().join("schema.json").to_str().unwrap()])
+        .arg(manifest_path("tests/fixtures/cdi-v1.1-good.yaml"))
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("no sibling defs.json"), "{stderr}");
+}
+
+#[test]
+fn validate_cli_accepts_standalone_custom_schema() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("schema.json"), r#"{"type": "object"}"#).unwrap();
+
+    let output = Command::new(validate_bin())
+        .args(["--schema", dir.path().join("schema.json").to_str().unwrap()])
+        .arg(manifest_path("tests/fixtures/cdi-v1.1-good.yaml"))
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{:?}", output);
+}


### PR DESCRIPTION
Line coverage 69.5% → 98.0%. Gates: 95% total, 95% per file, no exemptions.

## Fixes found while writing the tests

1. The default cache was not a singleton: `get_or_create_default_cache` created a local `OnceCell` and `take()`'d it per call, so `configure()` acted on a throwaway instance. Now a `static OnceCell`.
2. `is_qualified_name` dropped prefix validation errors (inverted `is_empty` check); invalid DNS-1123 prefixes validated successfully.
3. `Path::set_extension(".yaml")` produced `spec..yaml`; the extension must not contain the dot.

## Coverage setup

- Two test passes merged into one profile: root executes the mknod device tests, non-root their skip branches.
- The cdi CLI api is tested in-binary against a default cache configured to a temp spec dir; no `/etc/cdi` dependence.
- Generator init helpers: removed `if let` arms that cannot run (`init_config` guarantees `Some`), matching the style of the sibling helpers.

## Per-module (lines)

| module | before | after |
|---|---|---|
| default_cache, spec_dirs, k8s validation, cdi api | 0-39% | 96-100% |
| cache, container_edits, container_edits_unix | 39-78% | 95-100% |
| generate, spec, version, parser, annotations | 38-94% | 96-100% |

All suites pass under miri; process-spawning CLI tests are `cfg(not(miri))`.
