### PR TITLE
chore: bump version to 1.1.0 for CDI spec v1.1.0 parity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,7 +285,7 @@ dependencies = [
 
 [[package]]
 name = "container-device-interface"
-version = "0.2.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "container-device-interface"
-version = "0.2.0"
+version = "1.1.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "CDI (Container Device Interface), is a specification, for container-runtimes, to support third-party devices."


### PR DESCRIPTION
Bumps the crate version to 1.1.0, matching container-device-interface (Go) v1.1.0 now that #78 brought full parity.

Cargo.lock is refreshed in the same commit so the `--locked` release builds stay green.

Once merged, dispatch the **Release and Publish Rust Crate** workflow from `main` to tag `v1.1.0` and publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)