### PR TITLE
fix: release SBOM job died on a missing dist directory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,16 +46,34 @@ jobs:
           TAG="v${FILE_VERSION}"
           echo "file_version=${FILE_VERSION}" >> "$GITHUB_OUTPUT"
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-          # Create and push tag; if it already exists, this will fail (desired)
-          git tag "${TAG}"
-          git push origin "${TAG}"
+          # A tag pointing elsewhere means a version reuse - fail. Pointing at
+          # HEAD means a re-dispatch after a mid-pipeline failure - continue.
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            if [[ "$(git rev-parse "${TAG}^{commit}")" != "$(git rev-parse HEAD)" ]]; then
+              echo "::error::tag ${TAG} exists and does not point at HEAD"; exit 1
+            fi
+            echo "tag ${TAG} already at HEAD; skipping tag creation"
+          else
+            git tag "${TAG}"
+            git push origin "${TAG}"
+          fi
 
       # Trusted Publishing via OIDC: no CARGO_REGISTRY_TOKEN is needed.
       # Make sure the crate is configured on crates.io with a GitHub publisher link.
       - name: Publish
-        run: cargo publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+          VERSION: ${{ steps.version.outputs.file_version }}
+        run: |
+          set -Eeuo pipefail
+          # crates.io versions are immutable; on a re-dispatch after a
+          # mid-pipeline failure the publish is already done - skip, don't die.
+          if curl -fsS -A "container-device-interface release workflow" \
+            "https://crates.io/api/v1/crates/container-device-interface/${VERSION}" >/dev/null 2>&1; then
+            echo "version ${VERSION} already on crates.io; skipping publish"
+          else
+            cargo publish
+          fi
 
   # Build the release binaries (cdi, validate) and the cdylib per target,
   # package them as a reproducible tarball and keyless-sign it with cosign.
@@ -157,6 +175,11 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
           persist-credentials: false
+
+      # sbom-action writes output-file verbatim and does not create parent
+      # directories; without this the job dies with ENOENT after the scan.
+      - name: Create dist directory
+        run: mkdir -p dist
 
       - name: Generate SBOM (SPDX JSON)
         uses: anchore/sbom-action@f8bdd1d8ac5e901a77a92f111440fdb1b593736b # v0.20.6


### PR DESCRIPTION
The v1.1.0 release run ([29099675757](https://github.com/cncf-tags/container-device-interface-rs/actions/runs/29099675757)) failed in the SBOM job: `anchore/sbom-action` writes `output-file` verbatim and does not create parent directories, so it died with `ENOENT: dist/sbom-...spdx.json` right after a successful syft scan (the build jobs `mkdir -p dist` themselves; the SBOM job didn't).

Because the `publish` job had already pushed `v1.1.0` and published the crate before the SBOM failure, a plain re-dispatch would now die in `publish` instead. This PR therefore also makes that job re-entrant:

- tag creation is skipped when the tag already exists **and** points at HEAD (still fails if it points elsewhere — version reuse stays an error)
- `cargo publish` is skipped when the version is already on crates.io (versions are immutable)

After merging, re-dispatching the release workflow from `main` should sail through: publish becomes a no-op, artifacts rebuild reproducibly, and the draft release + provenance + verification complete.

No merge — leaving that to you per protocol.