### PR TITLE
docs: make the README speak to crates.io consumers

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,0 +1,38 @@
+# Building and reproducing releases
+
+## Build
+
+The compiler version is pinned in `rust-toolchain.toml`; rustup installs it
+on first use.
+
+```bash
+cargo build --release --locked
+```
+
+Release artifacts (`cdi`, `validate`, `libcontainer_device_interface.so`)
+are built with `./scripts/build-release.sh <target>`, which additionally
+remaps machine-specific paths so the artifacts are byte-reproducible. The
+`Reproducible build` workflow enforces this on every pull request by
+building twice from different locations and requiring identical hashes.
+
+Codegen policy (size optimization, LTO, `panic=abort`) lives in
+`[profile.release]` in `Cargo.toml`.
+
+## Reproduce a release build
+
+Signature checks prove *who* built an artifact; a rebuild proves *what* was
+built. Building a release tag yourself must yield exactly the published
+sha256:
+
+```bash
+git clone --branch "$TAG" --depth 1 \
+  https://github.com/cncf-tags/container-device-interface-rs
+cd container-device-interface-rs
+./scripts/build-release.sh "$TARGET"
+sha256sum "target/${TARGET}/release/cdi" \
+  "target/${TARGET}/release/validate" \
+  "target/${TARGET}/release/libcontainer_device_interface.so"
+```
+
+A mismatch means your toolchain deviates from `rust-toolchain.toml` (check
+`rustc -V`) or the artifact was not built from that tag.

--- a/README.md
+++ b/README.md
@@ -1,41 +1,46 @@
 # Container Device Interface (Rust)
 
 Rust implementation of the
-[Container Device Interface](https://github.com/cncf-tags/container-device-interface).
+[Container Device Interface](https://github.com/cncf-tags/container-device-interface)
+(CDI) specification, at parity with CDI v1.1.0.
 
-## Build
+CDI lets container runtimes support third-party devices (GPUs, FPGAs, and
+other accelerators) through vendor-provided JSON/YAML specs instead of
+runtime-specific plugins.
 
-The compiler version is pinned in `rust-toolchain.toml`; rustup installs it
-on first use.
-
-```bash
-cargo build --release --locked
-```
-
-Release artifacts (`cdi`, `validate`, `libcontainer_device_interface.so`)
-are built with `./scripts/build-release.sh <target>`, which additionally
-remaps machine-specific paths so the artifacts are byte-reproducible. The
-`Reproducible build` workflow enforces this on every pull request by
-building twice from different locations and requiring identical hashes.
-
-Codegen policy (size optimization, LTO, `panic=abort`) lives in
-`[profile.release]` in `Cargo.toml`.
-
-## Reproduce a release build
-
-Signature checks prove *who* built an artifact; a rebuild proves *what* was
-built. Building a release tag yourself must yield exactly the published
-sha256:
+## Library
 
 ```bash
-git clone --branch "$TAG" --depth 1 \
-  https://github.com/cncf-tags/container-device-interface-rs
-cd container-device-interface-rs
-./scripts/build-release.sh "$TARGET"
-sha256sum "target/${TARGET}/release/cdi" \
-  "target/${TARGET}/release/validate" \
-  "target/${TARGET}/release/libcontainer_device_interface.so"
+cargo add container-device-interface
 ```
 
-A mismatch means your toolchain deviates from `rust-toolchain.toml` (check
-`rustc -V`) or the artifact was not built from that tag.
+The API mirrors the Go implementation: CDI specs are discovered from the
+standard spec directories and requested devices are injected into an OCI
+runtime spec:
+
+```rust
+use container_device_interface::default_cache;
+use oci_spec::runtime::Spec;
+
+let mut oci_spec = Spec::default();
+default_cache::inject_devices(&mut oci_spec, vec!["vendor.com/device=gpu0".into()])?;
+```
+
+Full API documentation: <https://docs.rs/container-device-interface>
+
+## Binaries and signed artifacts
+
+Each release ships the `cdi` and `validate` CLI tools and the
+`libcontainer_device_interface.so` cdylib for x86_64 and aarch64 as
+reproducible tarballs with cosign signatures, an SPDX SBOM, and SLSA
+provenance. Artifacts and verification material are on the
+[releases page](https://github.com/cncf-tags/container-device-interface-rs/releases).
+
+## Building from source
+
+See [BUILDING.md](BUILDING.md) for local builds and for
+reproducing release artifacts bit-for-bit.
+
+## License
+
+Apache-2.0


### PR DESCRIPTION
The README is what crates.io renders as the crate's landing page, but it only covered building and reproducing releases — nothing about what the crate is or how to use it.

- Lead with the crate's purpose (CDI spec parity v1.1.0) and a minimal `inject_devices` usage example
- Point to docs.rs and to the [releases page](https://github.com/cncf-tags/container-device-interface-rs/releases) for signed artifacts
- Move the build/reproduce material to `BUILDING.md` unchanged (root, since `docs/` is gitignored)

Merging this before the 1.1.1 dispatch puts the new README on the crates.io page.