### PR TITLE
chore: bump version to 1.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,7 +285,7 @@ dependencies = [
 
 [[package]]
 name = "container-device-interface"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "container-device-interface"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "CDI (Container Device Interface), is a specification, for container-runtimes, to support third-party devices."


### PR DESCRIPTION
Bumps the crate to 1.1.1, superseding the burned 1.1.0 (its crates.io upload is immutable and predates the README rework in #99). Still at CDI spec parity v1.1.0. Cargo.lock refreshed in the same commit; `cargo check --locked` passes.

After merging, dispatch **Release and Publish Rust Crate** from `main`. With the reordered pipeline (#98) this builds, verifies, and publishes the v1.1.1 GitHub release first and publishes to crates.io last — putting the new README on the crate's landing page.