### PR TITLE
ci: grant pull-requests write to the dependabot label job

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -44,6 +44,7 @@ jobs:
     if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
     permissions:
       issues: write # labels ride the Issues API even on PRs
+      pull-requests: write # labeling a PR checks this scope, not just issues
     steps:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:


### PR DESCRIPTION
The `label` job in `dependabot-auto-merge.yaml` fails with `Resource not accessible by integration` ([example run](https://github.com/cncf-tags/container-device-interface-rs/actions/runs/31023551196/job/92366108764)): `issues.addLabels` on a **pull request** is authorized against the `pull-requests` scope, not only `issues`. The `auto-merge` job in the same run succeeds because it already carries `pull-requests: write`, and the predecessor `ok-to-test` workflow carried both scopes for exactly this reason.

One-line fix: add `pull-requests: write` to the `label` job's permissions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)