### PR TITLE
ci: bypass ok-to-test gate for dependabot and drop label job

### DIFF
--- a/.github/workflows/ci-on-push.yaml
+++ b/.github/workflows/ci-on-push.yaml
@@ -26,11 +26,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Detect if only docs changed - skip CI if so
-  # Only run if ok-to-test label present (security gate for self-hosted runner)
+  # Detect if only docs changed - skip CI if so.
+  # Gate: ok-to-test label required for human PRs; dependabot bypasses the label.
   changes:
     name: Detect changes (e2e)
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'ok-to-test') ||
+      github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     outputs:
       code: ${{ steps.filter.outputs.code }}
@@ -62,8 +64,11 @@ jobs:
 
   ci:
     needs: changes
-    # Only run on self-hosted runner if: 1) ok-to-test label present (security), 2) code changed (efficiency)
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') && needs.changes.outputs.code == 'true' }}
+    # Only run on self-hosted runner if: 1) approved (security), 2) code changed (efficiency)
+    if: |
+      needs.changes.outputs.code == 'true' &&
+      (contains(github.event.pull_request.labels.*.name, 'ok-to-test') ||
+       github.event.pull_request.user.login == 'dependabot[bot]')
     permissions:
       contents: read
     uses: ./.github/workflows/ci.yaml
@@ -78,7 +83,10 @@ jobs:
   ci-complete:
     name: CI Complete
     needs: [changes, ci]
-    if: always() && contains(github.event.pull_request.labels.*.name, 'ok-to-test')
+    if: |
+      always() &&
+      (contains(github.event.pull_request.labels.*.name, 'ok-to-test') ||
+       github.event.pull_request.user.login == 'dependabot[bot]')
     runs-on: ubuntu-latest
     steps:
       - name: Check CI result


### PR DESCRIPTION
ci-on-push.yaml now allows dependabot[bot] PRs through the runner gate directly, without waiting for the ok-to-test label. This eliminates the race where the label arrived after the opened event and caused either a missed CI run or a double-run (labeled re-trigger cancelling the in-progress opened run via the concurrency group).

With the label no longer needed for CI, the label job in the automation workflow is redundant and removed. Human PRs still require ok-to-test.


Assisted-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>