### PR TITLE
fix(cache): remove same-priority device conflicts

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -212,7 +212,7 @@ impl Cache {
         }
 
         for conflict in conflicts.iter() {
-            self.devices.remove(conflict);
+            devices.remove(conflict);
         }
 
         self.specs = specs;
@@ -406,6 +406,7 @@ devices:
 
         assert!(err.to_string().contains("conflicting device"));
         assert!(!cache.errors.is_empty());
+        assert!(cache.get_device("vendor.com/device=gpu0").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Make same-priority conflicts for a fully qualified CDI device name unresolvable after cache refresh. This aligns the Rust cache with the Go CDI cache, which removes conflicting names from the newly built local device map before installing it.

The Rust cache currently removes a conflict from `self.devices` and then overwrites that map with the rebuilt local `devices` map, leaving the conflict selectable despite `refresh()` reporting an error.

## Related Issue

No issue required: localized cache correctness fix.

## Changes

- Remove same-priority conflict names from the rebuilt local device map before assigning it to the cache.
- Assert that a same-priority duplicate reports a refresh conflict and cannot be resolved through `get_device`.

## Downstream motivation

OpenShell currently has a temporary workaround for this cache behavior in [NVIDIA/OpenShell#2775](https://github.com/NVIDIA/OpenShell/pull/2775). Once it updates to a release containing this fix, that workaround can be removed.

## Testing

- [x] `cargo test cache::tests`
- [ ] `cargo fmt --check` (the pinned Rust 1.94.0 toolchain lacks the `rustfmt` component in this environment)

## Checklist

- [x] Follows Conventional Commits
- [x] Commit is signed off (DCO)